### PR TITLE
New Abilities - Set 1

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@
  * https://jestjs.io/docs/configuration
  */
 
-import type {Config} from 'jest';
+import type { Config } from 'jest';
 
 const config: Config = {
     // All imported modules in your tests should be mocked automatically
@@ -36,12 +36,12 @@ const config: Config = {
     coverageProvider: 'v8',
 
     // A list of reporter names that Jest uses when writing coverage reports
-    // coverageReporters: [
-    //   "json",
-    //   "text",
-    //   "lcov",
-    //   "clover"
-    // ],
+    coverageReporters: [
+        'json',
+        // 'text',
+        'lcov',
+        'clover'
+    ],
 
     // An object that configures minimum threshold enforcement for coverage results
     // coverageThreshold: undefined,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "name": "@wholesome-sisters/auto-battler",
   "description": "classes and types for auto-battler server and client",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "name": "@wholesome-sisters/auto-battler",
   "description": "classes and types for auto-battler server and client",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup",

--- a/src/Ability/Ability.ts
+++ b/src/Ability/Ability.ts
@@ -1,11 +1,16 @@
-import Character from '../Character/Character';
-import AbilityId from './AbilityId';
+import type AttributeType from '../Character/Attributes/AttributeType';
+import type Character from '../Character/Character';
+import type StatType from '../Character/Stats/StatType';
+import type AttackType from '../types/AttackType';
+import type AbilityId from './AbilityId';
 
 interface Ability {
     id: AbilityId;
     name: string;
     description: (char?: Character) => string;
     func: (char: Character) => void;
+    scaling?: ReadonlyArray<'level' | AttributeType | StatType>;
+    attackType?: AttackType;
 }
 
 export default Ability;

--- a/src/Ability/Ability.ts
+++ b/src/Ability/Ability.ts
@@ -1,6 +1,8 @@
 import Character from '../Character/Character';
+import AbilityId from './AbilityId';
 
 interface Ability {
+    id: AbilityId;
     name: string;
     description: (char?: Character) => string;
     func: (char: Character) => void;

--- a/src/Ability/AbilityId.ts
+++ b/src/Ability/AbilityId.ts
@@ -1,11 +1,23 @@
 enum AbilityId {
-    Bless = 'Bless',
+    // Fighter
     DoubleStrike = 'DoubleStrike',
-    FerociousBite = 'FerociousBite',
-    Firebolt = 'Firebolt',
     ShieldWall = 'ShieldWall',
-    Vanish = 'Vanish',
+
+    // Priest
+    Bless = 'Bless',
+
+    // Ranger
+    SerpentSting = 'SerpentSting',
     WoundingShot = 'WoundingShot',
+
+    // Rogue
+    Vanish = 'Vanish',
+
+    // Wizard
+    Firebolt = 'Firebolt',
+
+    // Other
+    FerociousBite = 'FerociousBite',
 }
 
 export default AbilityId;

--- a/src/Ability/AbilityId.ts
+++ b/src/Ability/AbilityId.ts
@@ -3,6 +3,7 @@ enum AbilityId {
     DoubleStrike = 'DoubleStrike',
     FerociousBite = 'FerociousBite',
     Firebolt = 'Firebolt',
+    ShieldWall = 'ShieldWall',
     Vanish = 'Vanish',
     WoundingShot = 'WoundingShot',
 }

--- a/src/Ability/AbilityId.ts
+++ b/src/Ability/AbilityId.ts
@@ -11,6 +11,7 @@ enum AbilityId {
     WoundingShot = 'WoundingShot',
 
     // Rogue
+    EnvenomWeapon = 'EnvenomWeapon',
     Vanish = 'Vanish',
 
     // Wizard

--- a/src/Ability/AbilityId.ts
+++ b/src/Ability/AbilityId.ts
@@ -16,6 +16,7 @@ enum AbilityId {
 
     // Wizard
     Firebolt = 'Firebolt',
+    Frostbolt = 'Frostbolt',
 
     // Other
     FerociousBite = 'FerociousBite',

--- a/src/Ability/AbilityId.ts
+++ b/src/Ability/AbilityId.ts
@@ -1,0 +1,10 @@
+enum AbilityId {
+    Bless = 'Bless',
+    DoubleStrike = 'DoubleStrike',
+    FerociousBite = 'FerociousBite',
+    Firebolt = 'Firebolt',
+    Vanish = 'Vanish',
+    WoundingShot = 'WoundingShot',
+}
+
+export default AbilityId;

--- a/src/Ability/AbilityId.ts
+++ b/src/Ability/AbilityId.ts
@@ -5,6 +5,7 @@ enum AbilityId {
 
     // Priest
     Bless = 'Bless',
+    Smite = 'Smite',
 
     // Ranger
     SerpentSting = 'SerpentSting',

--- a/src/Ability/Bless.test.ts
+++ b/src/Ability/Bless.test.ts
@@ -23,3 +23,16 @@ test('Bless - 1 target', () => {
     Bless.func(char);
     expect(char.statusEffectManager.buffs[BuffId.Blessed]![getCharBattleId(char)].stacks).toBe(3);
 });
+
+describe('Bless Description', () => {
+    test('No Character', () => {
+        expect(Bless.description()).toBe(
+            'Increases Accuracy and Damage for 3 turns.'
+        );
+    });
+    test('With Character', () => {
+        expect(Bless.description(char)).toBe(
+            'Increases Accuracy by 5 and Damage by 4 for 3 turns.'
+        );
+    });
+});

--- a/src/Ability/Bless.ts
+++ b/src/Ability/Bless.ts
@@ -2,11 +2,13 @@ import BuffId from '../StatusEffect/types/BuffId';
 import Ability from './Ability';
 import Blessed from '../StatusEffect/Buffs/Blessed';
 import { formatNum } from '../util';
+import AbilityId from './AbilityId';
 
 const NAME = 'Bless';
 const STACKS = 3;
 
 const Bless: Ability = {
+    id: AbilityId.Bless,
     name: NAME,
     description: (char) => {
         let damage = null;
@@ -27,6 +29,6 @@ const Bless: Ability = {
             stacks: STACKS
         }));
     }
-};
+} as const;
 
 export default Bless;

--- a/src/Ability/Bless.ts
+++ b/src/Ability/Bless.ts
@@ -1,4 +1,3 @@
-import BuffId from '../StatusEffect/types/BuffId';
 import Ability from './Ability';
 import Blessed from '../StatusEffect/Buffs/Blessed';
 import { formatNum } from '../util';
@@ -18,7 +17,7 @@ const Bless: Ability = {
             accuracy = Blessed.calcAccuracy(char.level, char.attributes.wisdom);
             damage = Blessed.calcDamage(char.level, char.attributes.wisdom);
         }
-        return `Gain ${STACKS} ${BuffId.Blessed} stacks, increasing Accuracy${accuracy ? ` by ${formatNum(accuracy)}` : ''} and Damage${damage ? ` by ${formatNum(damage)}` : ''}.`;
+        return `Increases Accuracy${accuracy ? ` by ${formatNum(accuracy)}` : ''} and Damage${damage ? ` by ${formatNum(damage)}` : ''} for ${STACKS} turns.`;
     },
     func: (char) => {
         char.useAbilityMana();

--- a/src/Ability/Bless.ts
+++ b/src/Ability/Bless.ts
@@ -3,6 +3,7 @@ import Ability from './Ability';
 import Blessed from '../StatusEffect/Buffs/Blessed';
 import { formatNum } from '../util';
 import AbilityId from './AbilityId';
+import AttributeType from '../Character/Attributes/AttributeType';
 
 const NAME = 'Bless';
 const STACKS = 3;
@@ -28,7 +29,8 @@ const Bless: Ability = {
             source: char,
             stacks: STACKS
         }));
-    }
+    },
+    scaling: ['level', AttributeType.Wisdom]
 } as const;
 
 export default Bless;

--- a/src/Ability/DoubleStrike.ts
+++ b/src/Ability/DoubleStrike.ts
@@ -6,7 +6,7 @@ const NAME = 'Double Strike';
 const DoubleStrike: Ability = {
     id: AbilityId.DoubleStrike,
     name: NAME,
-    description: () => 'Attack an enemy twice with your weapon(s).',
+    description: () => 'Attack your target twice with your weapon(s).',
     func: (char) => {
         if (char.target) {
             if (char.battle) char.battle.ref.log.add(`${char.name} used ${NAME}.`);

--- a/src/Ability/DoubleStrike.ts
+++ b/src/Ability/DoubleStrike.ts
@@ -1,8 +1,10 @@
 import Ability from './Ability';
+import AbilityId from './AbilityId';
 
 const NAME = 'Double Strike';
 
 const DoubleStrike: Ability = {
+    id: AbilityId.DoubleStrike,
     name: NAME,
     description: () => 'Attack an enemy twice with your weapon(s).',
     func: (char) => {
@@ -13,6 +15,6 @@ const DoubleStrike: Ability = {
             char.turnAttack();
         }
     }
-};
+} as const;
 
 export default DoubleStrike;

--- a/src/Ability/EnvenomWeapon.test.ts
+++ b/src/Ability/EnvenomWeapon.test.ts
@@ -1,0 +1,28 @@
+import Battle from '../Battle/Battle';
+import Character from '../Character/Character';
+import StatType from '../Character/Stats/StatType';
+import BuffId from '../StatusEffect/types/BuffId';
+import { createTestCharacter } from '../tests/util';
+import { getCharBattleId } from '../util';
+import EnvenomWeapon from './EnvenomWeapon';
+
+let char: Character;
+beforeEach(() => {
+    char = createTestCharacter({
+        statTemplate: {
+            [StatType.ManaCost]: { base: 50 },
+            [StatType.StartingMana]: { base: 100 },
+        }
+    });
+
+    new Battle([char], []);
+});
+
+test('adds 3 stacks of used Envenom Weapon buff, and adds to log', () => {
+    expect(char.currentMana).toBe(100);
+    EnvenomWeapon.func(char);
+    expect(char.currentMana).toBe(50);
+    expect(char.statusEffectManager.buffs[BuffId.EnvenomWeapon]![getCharBattleId(char)].stacks).toBe(3);
+    expect(char.battle?.ref.log.last[0]).toEqual({ text: ' used Envenom Weapon.', type: 'Text' });
+});
+

--- a/src/Ability/EnvenomWeapon.test.ts
+++ b/src/Ability/EnvenomWeapon.test.ts
@@ -30,6 +30,6 @@ test('adds 3 stacks of used Envenom Weapon buff, and adds to log', () => {
 
 test('Description', () => {
     expect(EnvenomWeapon.description()).toBe(
-        `Your next 3 hits apply ${EnvenomWeaponBuff.POISONED_STACKS} ${Poisoned.name}.`
+        `Your next 3 hits applies ${EnvenomWeaponBuff.POISONED_STACKS} ${Poisoned.name}.`
     );
 });

--- a/src/Ability/EnvenomWeapon.test.ts
+++ b/src/Ability/EnvenomWeapon.test.ts
@@ -1,6 +1,8 @@
 import Battle from '../Battle/Battle';
 import Character from '../Character/Character';
 import StatType from '../Character/Stats/StatType';
+import EnvenomWeaponBuff from '../StatusEffect/Buffs/EnvenomWeapon';
+import Poisoned from '../StatusEffect/Debuffs/Poisoned';
 import BuffId from '../StatusEffect/types/BuffId';
 import { createTestCharacter } from '../tests/util';
 import { getCharBattleId } from '../util';
@@ -26,3 +28,8 @@ test('adds 3 stacks of used Envenom Weapon buff, and adds to log', () => {
     expect(char.battle?.ref.log.last[0]).toEqual({ text: ' used Envenom Weapon.', type: 'Text' });
 });
 
+test('Description', () => {
+    expect(EnvenomWeapon.description()).toBe(
+        `Your next 3 hits apply ${EnvenomWeaponBuff.POISONED_STACKS} ${Poisoned.name}.`
+    );
+});

--- a/src/Ability/EnvenomWeapon.ts
+++ b/src/Ability/EnvenomWeapon.ts
@@ -9,7 +9,7 @@ const STACKS = 3;
 const EnvenomWeapon: Ability = {
     id: AbilityId.EnvenomWeapon,
     name: NAME,
-    description: () => `Your next ${STACKS} hits apply 2 ${EnvenomWeaponBuff.POISONED_STACKS} ${Poisoned.name} stacks.`,
+    description: () => `Your next ${STACKS} hits apply ${EnvenomWeaponBuff.POISONED_STACKS} ${Poisoned.name}.`,
     func: (char) => {
         if (char.battle) char.battle.ref.log.add(`${char.name} used ${NAME}.`);
         char.useAbilityMana();

--- a/src/Ability/EnvenomWeapon.ts
+++ b/src/Ability/EnvenomWeapon.ts
@@ -9,7 +9,7 @@ const STACKS = 3;
 const EnvenomWeapon: Ability = {
     id: AbilityId.EnvenomWeapon,
     name: NAME,
-    description: () => `Your next ${STACKS} hits apply ${EnvenomWeaponBuff.POISONED_STACKS} ${Poisoned.name}.`,
+    description: () => `Your next ${STACKS} hits applies ${EnvenomWeaponBuff.POISONED_STACKS} ${Poisoned.name}.`,
     func: (char) => {
         if (char.battle) char.battle.ref.log.add(`${char.name} used ${NAME}.`);
         char.useAbilityMana();

--- a/src/Ability/EnvenomWeapon.ts
+++ b/src/Ability/EnvenomWeapon.ts
@@ -1,0 +1,24 @@
+import Poisoned from '../StatusEffect/Debuffs/Poisoned';
+import Ability from './Ability';
+import AbilityId from './AbilityId';
+import EnvenomWeaponBuff from '../StatusEffect/Buffs/EnvenomWeapon';
+
+const NAME = 'Envenom Weapon';
+const STACKS = 3;
+
+const EnvenomWeapon: Ability = {
+    id: AbilityId.EnvenomWeapon,
+    name: NAME,
+    description: () => `Your next ${STACKS} hits apply 2 ${EnvenomWeaponBuff.POISONED_STACKS} ${Poisoned.name} stacks.`,
+    func: (char) => {
+        if (char.battle) char.battle.ref.log.add(`${char.name} used ${NAME}.`);
+        char.useAbilityMana();
+        char.statusEffectManager.add(new EnvenomWeaponBuff({
+            char,
+            source: char,
+            stacks: STACKS
+        }));
+    }
+} as const;
+
+export default EnvenomWeapon;

--- a/src/Ability/FerociousBite.ts
+++ b/src/Ability/FerociousBite.ts
@@ -48,7 +48,8 @@ const FerociousBite: Ability = {
                 }));
             }
         }
-    }
+    },
+    attackType: AttackType.MeleeWeapon
 } as const;
 
 export default FerociousBite;

--- a/src/Ability/FerociousBite.ts
+++ b/src/Ability/FerociousBite.ts
@@ -2,6 +2,7 @@ import AttackType from '../types/AttackType';
 import Ability from './Ability';
 import { formatNum } from '../util';
 import Bleeding from '../StatusEffect/Debuffs/Bleeding';
+import AbilityId from './AbilityId';
 
 const NAME = 'Ferocious Bite';
 const BONUS_DMG = 0.25;
@@ -9,6 +10,7 @@ const BLEED_STACKS = 2;
 const DMG_PER_TURN = 0.15;
 
 const FerociousBite: Ability = {
+    id: AbilityId.FerociousBite,
     name: NAME,
     description: (char) => {
         const damageRange = char ? char.calcDamageRange({
@@ -47,6 +49,6 @@ const FerociousBite: Ability = {
             }
         }
     }
-};
+} as const;
 
 export default FerociousBite;

--- a/src/Ability/Firebolt.test.ts
+++ b/src/Ability/Firebolt.test.ts
@@ -79,12 +79,12 @@ describe('Firebolt Damage and Debuff', () => {
 describe('Firebolt Description', () => {
     test('No Character', () => {
         expect(Firebolt.description()).toBe(
-            'Deals damage to your target and apply 2 Burning, dealing damage each turn.'
+            'Deals damage to your target and applies 2 Burning, dealing damage each turn.'
         );
     });
     test('Wth Character', () => {
         expect(Firebolt.description(char)).toBe(
-            'Deals 36-40 damage to your target and apply 2 Burning, dealing 21 damage each turn.'
+            'Deals 36-40 damage to your target and applies 2 Burning, dealing 21 damage each turn.'
         );
     });
 });

--- a/src/Ability/Firebolt.test.ts
+++ b/src/Ability/Firebolt.test.ts
@@ -35,18 +35,13 @@ beforeEach(() => {
 
 describe('Firebolt Damage and Debuff', () => {
     let mathRandomSpy: jest.SpyInstance;
-    beforeEach(() => {
-        mathRandomSpy = jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
-    });
-    afterEach(() => {
-        mathRandomSpy.mockRestore();
-    });
-
     let hitRollSpy: jest.SpyInstance;
     beforeEach(() => {
+        mathRandomSpy = jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
         hitRollSpy = jest.spyOn(Character.prototype, 'hitRoll');
     });
     afterEach(() => {
+        mathRandomSpy.mockRestore();
         hitRollSpy.mockRestore();
     });
 

--- a/src/Ability/Firebolt.test.ts
+++ b/src/Ability/Firebolt.test.ts
@@ -6,6 +6,9 @@ import { createTestCharacter } from '../tests/util';
 import { getCharBattleId } from '../util';
 import Firebolt from './Firebolt';
 
+describe('Firebolt Damage and Burning Debuff', () => {
+
+});
 let char: Character;
 let target: Character;
 
@@ -30,42 +33,58 @@ beforeEach(() => {
     new Battle([char], [target]);
 });
 
-let mathRandomSpy: jest.SpyInstance;
-beforeEach(() => {
-    mathRandomSpy = jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
-});
-afterEach(() => {
-    mathRandomSpy.mockRestore();
+describe('Firebolt Damage and Debuff', () => {
+    let mathRandomSpy: jest.SpyInstance;
+    beforeEach(() => {
+        mathRandomSpy = jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
+    });
+    afterEach(() => {
+        mathRandomSpy.mockRestore();
+    });
+
+    let hitRollSpy: jest.SpyInstance;
+    beforeEach(() => {
+        hitRollSpy = jest.spyOn(Character.prototype, 'hitRoll');
+    });
+    afterEach(() => {
+        hitRollSpy.mockRestore();
+    });
+
+    test('Firebolt Hit', () => {
+        hitRollSpy.mockReturnValue(true);
+        Firebolt.func(char);
+        expect(target.currentHealth).toBe(62);
+        expect(char.currentMana).toBe(50);
+        expect(target.statusEffectManager.debuffs[DebuffId.Burning]![getCharBattleId(char)].stacks).toBe(2);
+    });
+
+    test('Firebolt Miss', () => {
+        hitRollSpy.mockReturnValue(false);
+        Firebolt.func(char);
+        expect(target.currentHealth).toBe(100);
+        expect(char.currentMana).toBe(50);
+        expect(target.statusEffectManager.debuffs[DebuffId.Burning]).toBeUndefined();
+    });
+
+    test('Firebolt No Target', () => {
+        char.target = null;
+        Firebolt.func(char);
+        expect(target.currentHealth).toBe(100);
+        expect(char.currentMana).toBe(100);
+        expect(target.statusEffectManager.debuffs[DebuffId.Burning]).toBeUndefined();
+    });
 });
 
-let hitRollSpy: jest.SpyInstance;
-beforeEach(() => {
-    hitRollSpy = jest.spyOn(Character.prototype, 'hitRoll');
-});
-afterEach(() => {
-    hitRollSpy.mockRestore();
-});
 
-test('Firebolt Hit', () => {
-    hitRollSpy.mockReturnValue(true);
-    Firebolt.func(char);
-    expect(target.currentHealth).toBe(62);
-    expect(char.currentMana).toBe(50);
-    expect(target.statusEffectManager.debuffs[DebuffId.Burning]![getCharBattleId(char)].stacks).toBe(2);
-});
-
-test('Firebolt Miss', () => {
-    hitRollSpy.mockReturnValue(false);
-    Firebolt.func(char);
-    expect(target.currentHealth).toBe(100);
-    expect(char.currentMana).toBe(50);
-    expect(target.statusEffectManager.debuffs[DebuffId.Burning]).toBeUndefined();
-});
-
-test('Firebolt No Target', () => {
-    char.target = null;
-    Firebolt.func(char);
-    expect(target.currentHealth).toBe(100);
-    expect(char.currentMana).toBe(100);
-    expect(target.statusEffectManager.debuffs[DebuffId.Burning]).toBeUndefined();
+describe('Firebolt Description', () => {
+    test('No Character', () => {
+        expect(Firebolt.description()).toBe(
+            'Deals damage to your target and apply 2 Burning, dealing damage each turn.'
+        );
+    });
+    test('Wth Character', () => {
+        expect(Firebolt.description(char)).toBe(
+            'Deals 36 - 40 damage to your target and apply 2 Burning, dealing 21 damage each turn.'
+        );
+    });
 });

--- a/src/Ability/Firebolt.test.ts
+++ b/src/Ability/Firebolt.test.ts
@@ -84,7 +84,7 @@ describe('Firebolt Description', () => {
     });
     test('Wth Character', () => {
         expect(Firebolt.description(char)).toBe(
-            'Deals 36 - 40 damage to your target and apply 2 Burning, dealing 21 damage each turn.'
+            'Deals 36-40 damage to your target and apply 2 Burning, dealing 21 damage each turn.'
         );
     });
 });

--- a/src/Ability/Firebolt.test.ts
+++ b/src/Ability/Firebolt.test.ts
@@ -11,7 +11,7 @@ let target: Character;
 
 beforeEach(() => {
     char = createTestCharacter({
-        level: 10,
+        level: 11,
         statTemplate: {
             [StatType.MaxHealth]: { base: 100 },
             [StatType.SpellPower]: { base: 100 },

--- a/src/Ability/Firebolt.ts
+++ b/src/Ability/Firebolt.ts
@@ -19,8 +19,8 @@ const Firebolt: Ability = {
     description: (char) => {
         const damageRange = char ? char.calcDamageRange({
             damageRange: {
-                min: MIN_BASE + char.level * MIN_PER_LVL,
-                max: MAX_BASE + char.level * MAX_PER_LVL,
+                min: MIN_BASE + (char.level - 1) * MIN_PER_LVL,
+                max: MAX_BASE + (char.level - 1) * MAX_PER_LVL,
                 bonus: 0,
             },
             weaponAttack: false,
@@ -35,8 +35,8 @@ const Firebolt: Ability = {
                 target: char.target,
                 attackType: AttackType.Spell,
                 damageRange: {
-                    min: MIN_BASE + char.level * MIN_PER_LVL,
-                    max: MAX_BASE + char.level * MAX_PER_LVL,
+                    min: MIN_BASE + (char.level - 1) * MIN_PER_LVL,
+                    max: MAX_BASE + (char.level - 1) * MAX_PER_LVL,
                     bonus: 0
                 },
                 weaponAttack: false,

--- a/src/Ability/Firebolt.ts
+++ b/src/Ability/Firebolt.ts
@@ -26,7 +26,7 @@ const Firebolt: Ability = {
             weaponAttack: false,
             spellPowerRatio: SPELLPOWER_RATIO
         }) : null;
-        return `Deals ${damageRange ? `${formatNum(damageRange.min)} - ${formatNum(damageRange.max)} ` : ''}damage to your target and apply ${STACKS} ${Burning.name}, dealing${char ? ` ${formatNum(Burning.baseDamage + char.stats.spellPower * Burning.spellPowerRatio)}` : ''} damage each turn.`;
+        return `Deals ${damageRange ? `${formatNum(damageRange.min)}-${formatNum(damageRange.max)} ` : ''}damage to your target and apply ${STACKS} ${Burning.name}, dealing${char ? ` ${formatNum(Burning.baseDamage + char.stats.spellPower * Burning.spellPowerRatio)}` : ''} damage each turn.`;
     },
     func: (char) => {
         if (char.target) {

--- a/src/Ability/Firebolt.ts
+++ b/src/Ability/Firebolt.ts
@@ -2,6 +2,7 @@ import AttackType from '../types/AttackType';
 import Ability from './Ability';
 import Burning from '../StatusEffect/Debuffs/Burning';
 import { formatNum } from '../util';
+import AbilityId from './AbilityId';
 
 const NAME = 'Firebolt';
 const MIN_BASE = 1;
@@ -12,6 +13,7 @@ const SPELLPOWER_RATIO = 0.34;
 const STACKS = 2;
 
 const Firebolt: Ability = {
+    id: AbilityId.Firebolt,
     name: NAME,
     description: (char) => {
         const damageRange = char ? char.calcDamageRange({
@@ -51,6 +53,6 @@ const Firebolt: Ability = {
             }
         }
     }
-};
+} as const;
 
 export default Firebolt;

--- a/src/Ability/Firebolt.ts
+++ b/src/Ability/Firebolt.ts
@@ -26,7 +26,7 @@ const Firebolt: Ability = {
             weaponAttack: false,
             spellPowerRatio: SPELLPOWER_RATIO
         }) : null;
-        return `Deals ${damageRange ? `${formatNum(damageRange.min)} - ${formatNum(damageRange.max)} ` : ''}to your target and apply ${STACKS} Burning stacks${char ? ` dealing ${formatNum(Burning.baseDamage + char.stats.spellPower * Burning.spellPowerRatio)} damage each turn` : ''}.`;
+        return `Deals ${damageRange ? `${formatNum(damageRange.min)} - ${formatNum(damageRange.max)} ` : ''}to your target and apply ${STACKS} ${Burning.name} stacks${char ? ` dealing ${formatNum(Burning.baseDamage + char.stats.spellPower * Burning.spellPowerRatio)} damage each turn` : ''}.`;
     },
     func: (char) => {
         if (char.target) {

--- a/src/Ability/Firebolt.ts
+++ b/src/Ability/Firebolt.ts
@@ -26,7 +26,7 @@ const Firebolt: Ability = {
             weaponAttack: false,
             spellPowerRatio: SPELLPOWER_RATIO
         }) : null;
-        return `Deals ${damageRange ? `${formatNum(damageRange.min)}-${formatNum(damageRange.max)} ` : ''}damage to your target and apply ${STACKS} ${Burning.name}, dealing${char ? ` ${formatNum(Burning.baseDamage + char.stats.spellPower * Burning.spellPowerRatio)}` : ''} damage each turn.`;
+        return `Deals ${damageRange ? `${formatNum(damageRange.min)}-${formatNum(damageRange.max)} ` : ''}damage to your target and applies ${STACKS} ${Burning.name}, dealing${char ? ` ${formatNum(Burning.baseDamage + char.stats.spellPower * Burning.spellPowerRatio)}` : ''} damage each turn.`;
     },
     func: (char) => {
         if (char.target) {

--- a/src/Ability/Firebolt.ts
+++ b/src/Ability/Firebolt.ts
@@ -3,6 +3,7 @@ import Ability from './Ability';
 import Burning from '../StatusEffect/Debuffs/Burning';
 import { formatNum } from '../util';
 import AbilityId from './AbilityId';
+import StatType from '../Character/Stats/StatType';
 
 const NAME = 'Firebolt';
 const MIN_BASE = 1;
@@ -52,7 +53,9 @@ const Firebolt: Ability = {
                 }));
             }
         }
-    }
+    },
+    scaling: ['level', StatType.SpellPower],
+    attackType: AttackType.Spell,
 } as const;
 
 export default Firebolt;

--- a/src/Ability/Firebolt.ts
+++ b/src/Ability/Firebolt.ts
@@ -26,7 +26,7 @@ const Firebolt: Ability = {
             weaponAttack: false,
             spellPowerRatio: SPELLPOWER_RATIO
         }) : null;
-        return `Deals ${damageRange ? `${formatNum(damageRange.min)} - ${formatNum(damageRange.max)} ` : ''}to your target and apply ${STACKS} ${Burning.name} stacks${char ? ` dealing ${formatNum(Burning.baseDamage + char.stats.spellPower * Burning.spellPowerRatio)} damage each turn` : ''}.`;
+        return `Deals ${damageRange ? `${formatNum(damageRange.min)} - ${formatNum(damageRange.max)} ` : ''}damage to your target and apply ${STACKS} ${Burning.name}, dealing${char ? ` ${formatNum(Burning.baseDamage + char.stats.spellPower * Burning.spellPowerRatio)}` : ''} damage each turn.`;
     },
     func: (char) => {
         if (char.target) {

--- a/src/Ability/Frostbolt.test.ts
+++ b/src/Ability/Frostbolt.test.ts
@@ -1,0 +1,83 @@
+import Battle from '../Battle/Battle';
+import Character from '../Character/Character';
+import StatType from '../Character/Stats/StatType';
+import * as diceModule from '../dice';
+import DebuffId from '../StatusEffect/types/DebuffId';
+import { createTestCharacter } from '../tests/util';
+import { getCharBattleId } from '../util';
+import Frostbolt from './Frostbolt';
+
+let char: Character;
+let target: Character;
+
+beforeEach(() => {
+    char = createTestCharacter({
+        level: 11,
+        statTemplate: {
+            [StatType.MaxHealth]: { base: 100 },
+            [StatType.SpellPower]: { base: 100 },
+            [StatType.StartingMana]: { base: 100 },
+            [StatType.ManaCost]: { base: 50 }
+        }
+    });
+
+    target = createTestCharacter({
+        statTemplate: {
+            [StatType.MaxHealth]: { base: 100 }
+        }
+    });
+
+    char.target = target;
+    new Battle([char], [target]);
+});
+
+let mathRandomSpy: jest.SpyInstance;
+let rollDiceSpy: jest.SpyInstance;
+let hitRollSpy: jest.SpyInstance;
+beforeEach(() => {
+    mathRandomSpy = jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
+    rollDiceSpy = jest.spyOn(diceModule, 'rollDice');
+    hitRollSpy = jest.spyOn(Character.prototype, 'hitRoll');
+});
+afterEach(() => {
+    mathRandomSpy.mockRestore();
+    hitRollSpy.mockRestore();
+});
+
+test('Frostbolt Miss', () => {
+    hitRollSpy.mockReturnValue(false);
+
+    Frostbolt.func(char);
+    expect(target.currentHealth).toBe(100);
+    expect(char.currentMana).toBe(50);
+    expect(target.statusEffectManager.debuffs[DebuffId.Frozen]).toBeUndefined();
+});
+
+test('Frostbolt Hit, No Freeze', () => {
+    hitRollSpy.mockReturnValue(true);
+    rollDiceSpy.mockReturnValue(51);
+
+    Frostbolt.func(char);
+    expect(target.currentHealth).toBe(47); // 100 - (2 to 4 + 100 * 0.5 = 53) = 47
+    expect(char.currentMana).toBe(50);
+    expect(target.statusEffectManager.debuffs[DebuffId.Frozen]).toBeUndefined();
+});
+
+test('Frostbolt Hit, Freeze', () => {
+    hitRollSpy.mockReturnValue(true);
+    rollDiceSpy.mockReturnValue(50);
+
+    Frostbolt.func(char);
+    expect(target.currentHealth).toBe(47); // 100 - (2 to 4 + 100 * 0.5 = 53) = 47
+    expect(char.currentMana).toBe(50);
+    expect(target.statusEffectManager.debuffs[DebuffId.Frozen]![getCharBattleId(char)].stacks).toBe(1);
+});
+
+test('Frostbolt No Target', () => {
+    char.target = null;
+
+    Frostbolt.func(char);
+    expect(target.currentHealth).toBe(100);
+    expect(char.currentMana).toBe(100);
+    expect(target.statusEffectManager.debuffs[DebuffId.Burning]).toBeUndefined();
+});

--- a/src/Ability/Frostbolt.test.ts
+++ b/src/Ability/Frostbolt.test.ts
@@ -87,12 +87,12 @@ describe('Frostbolt Damage and Debuff', () => {
 describe('Frostbolt Damage and Debuff', () => {
     test('No Character', () => {
         expect(Frostbolt.description()).toBe(
-            'Deals damage to your target. There\'s a 50% chance to apply 1 Frozen, preventing them from acting for 1 turn.'
+            'Deals damage to your target, with a 50% chance of applying 1 Frozen, preventing them from acting for 1 turn.'
         );
     });
     test('With Character', () => {
         expect(Frostbolt.description(char)).toBe(
-            'Deals 52-54 damage to your target. There\'s a 50% chance to apply 1 Frozen, preventing them from acting for 1 turn.'
+            'Deals 52-54 damage to your target, with a 50% chance of applying 1 Frozen, preventing them from acting for 1 turn.'
         );
     });
 });

--- a/src/Ability/Frostbolt.ts
+++ b/src/Ability/Frostbolt.ts
@@ -1,0 +1,63 @@
+import AttackType from '../types/AttackType';
+import Ability from './Ability';
+import { formatNum } from '../util';
+import AbilityId from './AbilityId';
+import StatType from '../Character/Stats/StatType';
+import Frozen from '../StatusEffect/Debuffs/Frozen';
+import { dice, rollDice } from '../dice';
+
+const NAME = 'Frostbolt';
+const MIN_BASE = 1;
+const MIN_PER_LVL = 0.1;
+const MAX_BASE = 2;
+const MAX_PER_LVL = 0.2;
+const SPELLPOWER_RATIO = 0.5;
+const STACKS = 1;
+const FROZEN_CHANCE = 50;
+
+const Frostbolt: Ability = {
+    id: AbilityId.Frostbolt,
+    name: NAME,
+    description: (char) => {
+        const damageRange = char ? char.calcDamageRange({
+            damageRange: {
+                min: MIN_BASE + (char.level - 1) * MIN_PER_LVL,
+                max: MAX_BASE + (char.level - 1) * MAX_PER_LVL,
+                bonus: 0,
+            },
+            weaponAttack: false,
+            spellPowerRatio: SPELLPOWER_RATIO
+        }) : null;
+        return `Deals ${damageRange ? `${formatNum(damageRange.min)} - ${formatNum(damageRange.max)} ` : ''}to your target. There's a ${FROZEN_CHANCE}% chance to apply 1 ${Frozen.name} stack, preventing them from acting for 1 turn.`;
+    },
+    func: (char) => {
+        if (char.target) {
+            char.useAbilityMana();
+            const { hit } = char.attack({
+                target: char.target,
+                attackType: AttackType.Spell,
+                damageRange: {
+                    min: MIN_BASE + (char.level - 1) * MIN_PER_LVL,
+                    max: MAX_BASE + (char.level - 1) * MAX_PER_LVL,
+                    bonus: 0
+                },
+                weaponAttack: false,
+                spellPowerRatio: SPELLPOWER_RATIO,
+                isOffHand: false,
+                abilityName: NAME
+            });
+
+            if (hit && rollDice(dice['1d100']) <= FROZEN_CHANCE) {
+                char.target.statusEffectManager.add(new Frozen({
+                    char: char.target,
+                    source: char,
+                    stacks: STACKS
+                }));
+            }
+        }
+    },
+    scaling: ['level', StatType.SpellPower],
+    attackType: AttackType.Spell,
+} as const;
+
+export default Frostbolt;

--- a/src/Ability/Frostbolt.ts
+++ b/src/Ability/Frostbolt.ts
@@ -28,7 +28,7 @@ const Frostbolt: Ability = {
             weaponAttack: false,
             spellPowerRatio: SPELLPOWER_RATIO
         }) : null;
-        return `Deals ${damageRange ? `${formatNum(damageRange.min)}-${formatNum(damageRange.max)} ` : ''}damage to your target. There's a ${FROZEN_CHANCE}% chance to apply 1 ${Frozen.name}, preventing them from acting for 1 turn.`;
+        return `Deals ${damageRange ? `${formatNum(damageRange.min)}-${formatNum(damageRange.max)} ` : ''}damage to your target, with a ${FROZEN_CHANCE}% chance of applying 1 ${Frozen.name}, preventing them from acting for 1 turn.`;
     },
     func: (char) => {
         if (char.target) {

--- a/src/Ability/Frostbolt.ts
+++ b/src/Ability/Frostbolt.ts
@@ -28,7 +28,7 @@ const Frostbolt: Ability = {
             weaponAttack: false,
             spellPowerRatio: SPELLPOWER_RATIO
         }) : null;
-        return `Deals ${damageRange ? `${formatNum(damageRange.min)} - ${formatNum(damageRange.max)} ` : ''}to your target. There's a ${FROZEN_CHANCE}% chance to apply 1 ${Frozen.name} stack, preventing them from acting for 1 turn.`;
+        return `Deals ${damageRange ? `${formatNum(damageRange.min)}-${formatNum(damageRange.max)} ` : ''}damage to your target. There's a ${FROZEN_CHANCE}% chance to apply 1 ${Frozen.name}, preventing them from acting for 1 turn.`;
     },
     func: (char) => {
         if (char.target) {

--- a/src/Ability/SerpentSting.test.ts
+++ b/src/Ability/SerpentSting.test.ts
@@ -48,11 +48,14 @@ beforeEach(() => {
 });
 
 let hitRollSpy: jest.SpyInstance;
+let critRollSpy: jest.SpyInstance;
 beforeEach(() => {
     hitRollSpy = jest.spyOn(Character.prototype, 'hitRoll').mockReturnValue(true);
+    critRollSpy = jest.spyOn(Character, 'critRoll').mockReturnValue(false);
 });
 afterEach(() => {
     hitRollSpy.mockRestore();
+    critRollSpy.mockRestore();
 });
 
 test('SerpentSting.func', () => {

--- a/src/Ability/SerpentSting.test.ts
+++ b/src/Ability/SerpentSting.test.ts
@@ -1,0 +1,66 @@
+import Battle from '../Battle/Battle';
+import Character from '../Character/Character';
+import StatType from '../Character/Stats/StatType';
+import { EquipSlot } from '../Equipment/Equipment';
+import { ItemType } from '../Equipment/Item';
+import { Weapon, WeaponType } from '../Equipment/Weapon/Weapon';
+import DebuffId from '../StatusEffect/types/DebuffId';
+import { createTestCharacter } from '../tests/util';
+import AttackType from '../types/AttackType';
+import { getCharBattleId } from '../util';
+import SerpentSting from './SerpentSting';
+
+let char: Character;
+let target: Character;
+const testWeapon: Weapon = {
+    id: 'longbow0',
+    itemType: ItemType.Weapon,
+    name: '',
+    tier: 0,
+    type: WeaponType.Bow,
+    attackType: AttackType.RangedWeapon,
+    damageRange: { min: 8, max: 8, bonus: 0 },
+};
+
+beforeEach(() => {
+    char = createTestCharacter({
+        level: 10,
+        statTemplate: {
+            [StatType.MaxHealth]: { base: 100 },
+            [StatType.SpellPower]: { base: 100 },
+            [StatType.StartingMana]: { base: 100 },
+            [StatType.ManaCost]: { base: 50 }
+        },
+        equipment: {
+            [EquipSlot.MainHand]: testWeapon
+        }
+    });
+
+    target = createTestCharacter({
+        statTemplate: {
+            [StatType.MaxHealth]: { base: 100 },
+            [StatType.Dodge]: { base: 0 }
+        }
+    });
+
+    char.target = target;
+    new Battle([char], [target]);
+});
+
+let hitRollSpy: jest.SpyInstance;
+beforeEach(() => {
+    hitRollSpy = jest.spyOn(Character.prototype, 'hitRoll').mockReturnValue(true);
+});
+afterEach(() => {
+    hitRollSpy.mockRestore();
+});
+
+test('SerpentSting.func', () => {
+    SerpentSting.func(char);
+    // 8 * 1.25 = 10 damage
+    expect(target.currentHealth).toBeCloseTo(90); // 100 - 10
+    expect(char.currentMana).toBe(50);
+
+    const poisonedDebuff = target.statusEffectManager.debuffs[DebuffId.Poisoned]![getCharBattleId(char)];
+    expect(poisonedDebuff.stacks).toBe(4);
+});

--- a/src/Ability/SerpentSting.test.ts
+++ b/src/Ability/SerpentSting.test.ts
@@ -74,12 +74,12 @@ describe('Serpent Sting Damage and Debuff', () => {
 describe('Serpent Sting Description', () => {
     test('No Character', () => {
         expect(SerpentSting.description()).toBe(
-            `Deal damage and apply 4 ${Poisoned.name}.`
+            `Deals damage and applies 4 ${Poisoned.name}.`
         );
     });
     test('With Character', () => {
         expect(SerpentSting.description(char)).toBe(
-            `Deal 10-10 damage and apply 4 ${Poisoned.name}.`
+            `Deals 10-10 damage and applies 4 ${Poisoned.name}.`
         );
     });
 });

--- a/src/Ability/SerpentSting.test.ts
+++ b/src/Ability/SerpentSting.test.ts
@@ -4,6 +4,7 @@ import StatType from '../Character/Stats/StatType';
 import { EquipSlot } from '../Equipment/Equipment';
 import { ItemType } from '../Equipment/Item';
 import { Weapon, WeaponType } from '../Equipment/Weapon/Weapon';
+import Poisoned from '../StatusEffect/Debuffs/Poisoned';
 import DebuffId from '../StatusEffect/types/DebuffId';
 import { createTestCharacter } from '../tests/util';
 import AttackType from '../types/AttackType';
@@ -47,23 +48,38 @@ beforeEach(() => {
     new Battle([char], [target]);
 });
 
-let hitRollSpy: jest.SpyInstance;
-let critRollSpy: jest.SpyInstance;
-beforeEach(() => {
-    hitRollSpy = jest.spyOn(Character.prototype, 'hitRoll').mockReturnValue(true);
-    critRollSpy = jest.spyOn(Character, 'critRoll').mockReturnValue(false);
-});
-afterEach(() => {
-    hitRollSpy.mockRestore();
-    critRollSpy.mockRestore();
+describe('Serpent Sting Damage and Debuff', () => {
+    let hitRollSpy: jest.SpyInstance;
+    let critRollSpy: jest.SpyInstance;
+    beforeEach(() => {
+        hitRollSpy = jest.spyOn(Character.prototype, 'hitRoll').mockReturnValue(true);
+        critRollSpy = jest.spyOn(Character, 'critRoll').mockReturnValue(false);
+    });
+    afterEach(() => {
+        hitRollSpy.mockRestore();
+        critRollSpy.mockRestore();
+    });
+
+    test('SerpentSting.func', () => {
+        SerpentSting.func(char);
+        // 8 * 1.25 = 10 damage
+        expect(target.currentHealth).toBeCloseTo(90); // 100 - 10
+        expect(char.currentMana).toBe(50);
+
+        const poisonedDebuff = target.statusEffectManager.debuffs[DebuffId.Poisoned]![getCharBattleId(char)];
+        expect(poisonedDebuff.stacks).toBe(4);
+    });
 });
 
-test('SerpentSting.func', () => {
-    SerpentSting.func(char);
-    // 8 * 1.25 = 10 damage
-    expect(target.currentHealth).toBeCloseTo(90); // 100 - 10
-    expect(char.currentMana).toBe(50);
-
-    const poisonedDebuff = target.statusEffectManager.debuffs[DebuffId.Poisoned]![getCharBattleId(char)];
-    expect(poisonedDebuff.stacks).toBe(4);
+describe('Serpent Sting Description', () => {
+    test('No Character', () => {
+        expect(SerpentSting.description()).toBe(
+            `Deal damage and apply 4 ${Poisoned.name}.`
+        );
+    });
+    test('With Character', () => {
+        expect(SerpentSting.description(char)).toBe(
+            `Deal 10-10 damage and apply 4 ${Poisoned.name}.`
+        );
+    });
 });

--- a/src/Ability/SerpentSting.ts
+++ b/src/Ability/SerpentSting.ts
@@ -21,7 +21,7 @@ const SerpentSting: Ability = {
             weaponAttack: true,
             spellPowerRatio: char.equipment.mainHand.spellPowerRatio ? char.equipment.mainHand.spellPowerRatio * (1 + BONUS_DMG) : char.equipment.mainHand.spellPowerRatio
         }) : null;
-        return `Deal ${damageRange ? `${formatNum(damageRange.min)}-${formatNum(damageRange.max)} ` : ''}damage and apply ${STACKS} ${Poisoned.name}.`;
+        return `Deals ${damageRange ? `${formatNum(damageRange.min)}-${formatNum(damageRange.max)} ` : ''}damage and applies ${STACKS} ${Poisoned.name}.`;
     },
     func: (char) => {
         if (char.target) {

--- a/src/Ability/SerpentSting.ts
+++ b/src/Ability/SerpentSting.ts
@@ -21,7 +21,7 @@ const SerpentSting: Ability = {
             weaponAttack: true,
             spellPowerRatio: char.equipment.mainHand.spellPowerRatio ? char.equipment.mainHand.spellPowerRatio * (1 + BONUS_DMG) : char.equipment.mainHand.spellPowerRatio
         }) : null;
-        return `Deals ${damageRange ? `${formatNum(damageRange.min)} - ${formatNum(damageRange.max)} ` : ''}damage and applies ${STACKS} ${Poisoned.name} stacks.`;
+        return `Deal ${damageRange ? `${formatNum(damageRange.min)}-${formatNum(damageRange.max)} ` : ''}damage and apply ${STACKS} ${Poisoned.name}.`;
     },
     func: (char) => {
         if (char.target) {

--- a/src/Ability/SerpentSting.ts
+++ b/src/Ability/SerpentSting.ts
@@ -1,0 +1,56 @@
+import AttackType from '../types/AttackType';
+import Ability from './Ability';
+import { formatNum } from '../util';
+import AbilityId from './AbilityId';
+import Poisoned from '../StatusEffect/Debuffs/Poisoned';
+
+const NAME = 'Serpent Sting';
+const BONUS_DMG = 0.25;
+const STACKS = 4;
+
+const SerpentSting: Ability = {
+    id: AbilityId.SerpentSting,
+    name: NAME,
+    description: (char) => {
+        const damageRange = char ? char.calcDamageRange({
+            damageRange: {
+                min: char.equipment.mainHand.damageRange.min * (1 + BONUS_DMG),
+                max: char.equipment.mainHand.damageRange.max * (1 + BONUS_DMG),
+                bonus: char.equipment.mainHand.damageRange.bonus * (1 + BONUS_DMG)
+            },
+            weaponAttack: true,
+            spellPowerRatio: char.equipment.mainHand.spellPowerRatio ? char.equipment.mainHand.spellPowerRatio * (1 + BONUS_DMG) : char.equipment.mainHand.spellPowerRatio
+        }) : null;
+        return `Deals ${damageRange ? `${formatNum(damageRange.min)} - ${formatNum(damageRange.max)} ` : ''}damage and applies ${STACKS} ${Poisoned.name} stacks.`;
+    },
+    func: (char) => {
+        if (char.target) {
+            char.useAbilityMana();
+            const mainHand = char.equipment.mainHand;
+            const { hit } = char.attack({
+                target: char.target,
+                attackType: AttackType.RangedWeapon,
+                damageRange: {
+                    min: mainHand.damageRange.min * (1 + BONUS_DMG),
+                    max: mainHand.damageRange.max * (1 + BONUS_DMG),
+                    bonus: mainHand.damageRange.bonus * (1 + BONUS_DMG)
+                },
+                weaponAttack: true,
+                spellPowerRatio: mainHand.spellPowerRatio ? mainHand.spellPowerRatio * (1 + BONUS_DMG) : mainHand.spellPowerRatio,
+                isOffHand: false,
+                abilityName: NAME
+            });
+
+            if (hit) {
+                char.target.statusEffectManager.add(new Poisoned({
+                    char: char.target,
+                    source: char,
+                    stacks: STACKS
+                }));
+            }
+        }
+    },
+    attackType: AttackType.RangedWeapon,
+} as const;
+
+export default SerpentSting;

--- a/src/Ability/ShieldWall.test.ts
+++ b/src/Ability/ShieldWall.test.ts
@@ -29,12 +29,12 @@ test('adds 3 stacks of ShieldWall buff, and adds to log', () => {
 describe('ShieldWall Description', () => {
     test('No Character', () => {
         expect(ShieldWall.description()).toBe(
-            'Increase Block Chance and Thorns for 3 turns.'
+            'Increases Block Chance and Thorns for 3 turns.'
         );
     });
     test('With Character', () => {
         expect(ShieldWall.description(char)).toBe(
-            'Increase Block Chance by 10% and Thorns by 2 for 3 turns.'
+            'Increases Block Chance by 10% and Thorns by 2 for 3 turns.'
         );
     });
 });

--- a/src/Ability/ShieldWall.test.ts
+++ b/src/Ability/ShieldWall.test.ts
@@ -1,0 +1,30 @@
+import ShieldWall from './ShieldWall';
+import Character from '../Character/Character';
+import Battle from '../Battle/Battle';
+import StatType from '../Character/Stats/StatType';
+import { createTestCharacter } from '../tests/util';
+import BuffId from '../StatusEffect/types/BuffId';
+import { getCharBattleId } from '../util';
+
+let char: Character;
+beforeEach(() => {
+    char = createTestCharacter({
+        statTemplate: {
+            [StatType.Damage]: { base: 0, perLvl: 0 },
+            [StatType.Accuracy]: { base: 0, perLvl: 0 },
+            [StatType.ManaCost]: { base: 100 },
+            [StatType.StartingMana]: { base: 100 },
+        }
+    });
+
+    new Battle([char], []);
+});
+
+test('adds 3 stacks of ShieldWall buff, and adds to log', () => {
+    expect(char.currentMana).toBe(100);
+    ShieldWall.func(char);
+    expect(char.currentMana).toBe(0);
+    expect(char.statusEffectManager.buffs[BuffId.ShieldWall]![getCharBattleId(char)].stacks).toBe(3);
+    expect(char.battle?.ref.log.last[0]).toEqual({ text: ' used Shield Wall.', type: 'Text' });
+});
+

--- a/src/Ability/ShieldWall.test.ts
+++ b/src/Ability/ShieldWall.test.ts
@@ -26,3 +26,15 @@ test('adds 3 stacks of ShieldWall buff, and adds to log', () => {
     expect(char.battle?.ref.log.last[0]).toEqual({ text: ' used Shield Wall.', type: 'Text' });
 });
 
+describe('ShieldWall Description', () => {
+    test('No Character', () => {
+        expect(ShieldWall.description()).toBe(
+            'Increase Block Chance and Thorns for 3 turns.'
+        );
+    });
+    test('With Character', () => {
+        expect(ShieldWall.description(char)).toBe(
+            'Increase Block Chance by 10% and Thorns by 2 for 3 turns.'
+        );
+    });
+});

--- a/src/Ability/ShieldWall.test.ts
+++ b/src/Ability/ShieldWall.test.ts
@@ -10,9 +10,7 @@ let char: Character;
 beforeEach(() => {
     char = createTestCharacter({
         statTemplate: {
-            [StatType.Damage]: { base: 0, perLvl: 0 },
-            [StatType.Accuracy]: { base: 0, perLvl: 0 },
-            [StatType.ManaCost]: { base: 100 },
+            [StatType.ManaCost]: { base: 50 },
             [StatType.StartingMana]: { base: 100 },
         }
     });
@@ -23,7 +21,7 @@ beforeEach(() => {
 test('adds 3 stacks of ShieldWall buff, and adds to log', () => {
     expect(char.currentMana).toBe(100);
     ShieldWall.func(char);
-    expect(char.currentMana).toBe(0);
+    expect(char.currentMana).toBe(50);
     expect(char.statusEffectManager.buffs[BuffId.ShieldWall]![getCharBattleId(char)].stacks).toBe(3);
     expect(char.battle?.ref.log.last[0]).toEqual({ text: ' used Shield Wall.', type: 'Text' });
 });

--- a/src/Ability/ShieldWall.ts
+++ b/src/Ability/ShieldWall.ts
@@ -17,7 +17,7 @@ const ShieldWall: Ability = {
             blockChance = ShieldWallBuff.calcBlockChance(char.level, char.attributes.strength);
             thorns = ShieldWallBuff.calcThorns(char.level, char.attributes.strength);
         }
-        return `Increase Block Chance${blockChance ? ` by ${formatNum(blockChance)}%` : ''} and Thorns${thorns ? ` by ${formatNum(thorns)}` : ''} for ${STACKS} turns.`;
+        return `Increases Block Chance${blockChance ? ` by ${formatNum(blockChance)}%` : ''} and Thorns${thorns ? ` by ${formatNum(thorns)}` : ''} for ${STACKS} turns.`;
     },
     func: (char) => {
         char.useAbilityMana();

--- a/src/Ability/ShieldWall.ts
+++ b/src/Ability/ShieldWall.ts
@@ -17,7 +17,7 @@ const ShieldWall: Ability = {
             blockChance = ShieldWallBuff.calcBlockChance(char.level, char.attributes.strength);
             thorns = ShieldWallBuff.calcThorns(char.level, char.attributes.strength);
         }
-        return `Gain ${ShieldWallBuff.name} for ${STACKS} turns, increasing Block Chance${blockChance ? ` by ${formatNum(blockChance)}` : ''} and Thorns${thorns ? ` by ${formatNum(thorns)}` : ''}.`;
+        return `Increase Block Chance${blockChance ? ` by ${formatNum(blockChance)}%` : ''} and Thorns${thorns ? ` by ${formatNum(thorns)}` : ''} for ${STACKS} turns.`;
     },
     func: (char) => {
         char.useAbilityMana();

--- a/src/Ability/ShieldWall.ts
+++ b/src/Ability/ShieldWall.ts
@@ -1,0 +1,32 @@
+import Ability from './Ability';
+import { formatNum } from '../util';
+import AbilityId from './AbilityId';
+import ShieldWallBuff from '../StatusEffect/Buffs/ShieldWall';
+
+const NAME = 'Shield Wall';
+const STACKS = 3;
+
+const ShieldWall: Ability = {
+    id: AbilityId.Bless,
+    name: NAME,
+    description: (char) => {
+        let blockChance = null;
+        let thorns = null;
+        if (char) {
+            blockChance = ShieldWallBuff.calcBlockChance(char.level, char.attributes.strength);
+            thorns = ShieldWallBuff.calcThorns(char.level, char.attributes.strength);
+        }
+        return `Gain ${ShieldWallBuff.name} for ${STACKS} turns, increasing Block Chance${blockChance ? ` by ${formatNum(blockChance)}` : ''} and Thorns${thorns ? ` by ${formatNum(thorns)}` : ''}.`;
+    },
+    func: (char) => {
+        char.useAbilityMana();
+        if (char.battle) char.battle.ref.log.add(`${char.name} used ${NAME}.`);
+        char.statusEffectManager.add(new ShieldWallBuff({
+            char,
+            source: char,
+            stacks: STACKS
+        }));
+    }
+} as const;
+
+export default ShieldWall;

--- a/src/Ability/ShieldWall.ts
+++ b/src/Ability/ShieldWall.ts
@@ -2,12 +2,13 @@ import Ability from './Ability';
 import { formatNum } from '../util';
 import AbilityId from './AbilityId';
 import ShieldWallBuff from '../StatusEffect/Buffs/ShieldWall';
+import AttributeType from '../Character/Attributes/AttributeType';
 
 const NAME = 'Shield Wall';
 const STACKS = 3;
 
 const ShieldWall: Ability = {
-    id: AbilityId.Bless,
+    id: AbilityId.ShieldWall,
     name: NAME,
     description: (char) => {
         let blockChance = null;
@@ -26,7 +27,8 @@ const ShieldWall: Ability = {
             source: char,
             stacks: STACKS
         }));
-    }
+    },
+    scaling: ['level', AttributeType.Strength],
 } as const;
 
 export default ShieldWall;

--- a/src/Ability/Smite.test.ts
+++ b/src/Ability/Smite.test.ts
@@ -1,0 +1,71 @@
+import Battle from '../Battle/Battle';
+import AttributeType from '../Character/Attributes/AttributeType';
+import Character from '../Character/Character';
+import StatType from '../Character/Stats/StatType';
+import DebuffId from '../StatusEffect/types/DebuffId';
+import { createTestCharacter } from '../tests/util';
+import { getCharBattleId } from '../util';
+import Smite from './Smite';
+
+let char: Character;
+let target: Character;
+
+beforeEach(() => {
+    char = createTestCharacter({
+        level: 11,
+        attributes: {
+            [AttributeType.Wisdom]: 20
+        },
+        statTemplate: {
+            [StatType.SpellPower]: { base: 100, perLvl: 0 },
+        }
+    });
+    target = createTestCharacter({
+        statTemplate: {
+            [StatType.MaxHealth]: { base: 100, perLvl: 0 },
+        }
+    });
+
+    char.target = target;
+    new Battle([char], [target]);
+});
+
+describe('Smite Damage and Debuff', () => {
+    let mathRandomSpy: jest.SpyInstance;
+    let hitRollSpy: jest.SpyInstance;
+    beforeEach(() => {
+        mathRandomSpy = jest.spyOn(global.Math, 'random').mockReturnValue(0.5);
+        hitRollSpy = jest.spyOn(Character.prototype, 'hitRoll');
+    });
+    afterEach(() => {
+        mathRandomSpy.mockRestore();
+        hitRollSpy.mockRestore();
+    });
+
+    test('Miss', () => {
+        hitRollSpy.mockReturnValue(false);
+        Smite.func(char);
+        expect(target.currentHealth).toBe(100);
+        expect(target.statusEffectManager.debuffs[DebuffId.Smote]).toBeUndefined();
+
+    });
+    test('Hit', () => {
+        hitRollSpy.mockReturnValue(true);
+        Smite.func(char);
+        expect(target.currentHealth).toBe(47); // 100 - (2 to 4 + 100 * 0.5 = 53) = 47
+        expect(target.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(char)].stacks).toBe(2);
+    });
+});
+
+describe('Smite Description', () => {
+    test('No Character', () => {
+        expect(Smite.description()).toBe(
+            'Deals damage to the target and reduces their Accuracy and Damage for 2 turns.'
+        );
+    });
+    test('With Character', () => {
+        expect(Smite.description(char)).toBe(
+            'Deals 52-54 damage to the target and reduces their Accuracy by 11 and Damage by 9 for 2 turns.'
+        );
+    });
+});

--- a/src/Ability/Smite.ts
+++ b/src/Ability/Smite.ts
@@ -1,0 +1,70 @@
+import AttackType from '../types/AttackType';
+import Ability from './Ability';
+import { formatNum } from '../util';
+import AbilityId from './AbilityId';
+import StatType from '../Character/Stats/StatType';
+import Smote from '../StatusEffect/Debuffs/Smote';
+import AttributeType from '../Character/Attributes/AttributeType';
+
+const NAME = 'Smite';
+const MIN_BASE = 1;
+const MIN_PER_LVL = 0.1;
+const MAX_BASE = 2;
+const MAX_PER_LVL = 0.2;
+const SPELLPOWER_RATIO = 0.5;
+const STACKS = 2;
+
+const Smite: Ability = {
+    id: AbilityId.Smite,
+    name: NAME,
+    description: (char) => {
+        const damageRange = char ? char.calcDamageRange({
+            damageRange: {
+                min: MIN_BASE + (char.level - 1) * MIN_PER_LVL,
+                max: MAX_BASE + (char.level - 1) * MAX_PER_LVL,
+                bonus: 0,
+            },
+            weaponAttack: false,
+            spellPowerRatio: SPELLPOWER_RATIO
+        }) : null;
+
+        let damage = null;
+        let accuracy = null;
+        if (char) {
+            accuracy = Smote.calcAccuracy(char.level, char.attributes.wisdom);
+            damage = Smote.calcDamage(char.level, char.attributes.wisdom);
+        }
+
+        return `Deals ${damageRange ? `${formatNum(damageRange.min)}-${formatNum(damageRange.max)} ` : ''}damage to the target and reduces their Accuracy${accuracy ? ` by ${formatNum(-accuracy)}` : ''} and Damage${damage ? ` by ${formatNum(-damage)}` : ''} for ${STACKS} turns.`;
+    },
+    func: (char) => {
+        if (char.target) {
+            char.useAbilityMana();
+            const { hit } = char.attack({
+                target: char.target,
+                attackType: AttackType.Spell,
+                damageRange: {
+                    min: MIN_BASE + (char.level - 1) * MIN_PER_LVL,
+                    max: MAX_BASE + (char.level - 1) * MAX_PER_LVL,
+                    bonus: 0
+                },
+                weaponAttack: false,
+                spellPowerRatio: SPELLPOWER_RATIO,
+                isOffHand: false,
+                abilityName: NAME
+            });
+
+            if (hit) {
+                char.target.statusEffectManager.add(new Smote({
+                    char: char.target,
+                    source: char,
+                    stacks: STACKS
+                }));
+            }
+        }
+    },
+    scaling: ['level', AttributeType.Wisdom, StatType.SpellPower],
+    attackType: AttackType.Spell,
+} as const;
+
+export default Smite;

--- a/src/Ability/Vanish.test.ts
+++ b/src/Ability/Vanish.test.ts
@@ -2,6 +2,7 @@ import Battle from '../Battle/Battle';
 import AttributeType from '../Character/Attributes/AttributeType';
 import Character from '../Character/Character';
 import StatType from '../Character/Stats/StatType';
+import Invisible from '../StatusEffect/Buffs/Invisible';
 import BuffId from '../StatusEffect/types/BuffId';
 import { createTestCharacter } from '../tests/util';
 import { getCharBattleId } from '../util';
@@ -9,78 +10,99 @@ import Vanish from './Vanish';
 
 let char: Character;
 
-test('Vanish - 0 Dexterity', () => {
-    char = createTestCharacter({
-        level: 10,
-        attributes: {
-            [AttributeType.Dexterity]: 5
-        },
-        statTemplate: {
-            [StatType.StartingMana]: { base: 100 },
-            [StatType.ManaCost]: { base: 50 }
-        }
-    });
-    new Battle([char], []);
+describe('Vanish Invisible Stacks', () => {
+    test('Vanish - 0 Dexterity', () => {
+        char = createTestCharacter({
+            level: 10,
+            attributes: {
+                [AttributeType.Dexterity]: 5
+            },
+            statTemplate: {
+                [StatType.StartingMana]: { base: 100 },
+                [StatType.ManaCost]: { base: 50 }
+            }
+        });
+        new Battle([char], []);
 
-    Vanish.func(char);
-    expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(4); // 1 + 4 - 1 = 4
-    expect(char.isInvisible()).toBe(true);
-    expect(char.currentMana).toBe(50);
+        Vanish.func(char);
+        expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(4); // 1 + 4 - 1 = 4
+        expect(char.isInvisible()).toBe(true);
+        expect(char.currentMana).toBe(50);
+    });
+
+    test('Vanish - 10 Dexterity', () => {
+        char = createTestCharacter({
+            level: 10,
+            attributes: {
+                [AttributeType.Dexterity]: 10
+            },
+            statTemplate: {
+                [StatType.StartingMana]: { base: 100 },
+                [StatType.ManaCost]: { base: 50 }
+            }
+        });
+        new Battle([char], []);
+
+        Vanish.func(char);
+        expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(5); // 1 + 4 + 0 = 5
+        expect(char.isInvisible()).toBe(true);
+        expect(char.currentMana).toBe(50);
+    });
+
+    test('Vanish - 20 Dexterity', () => {
+        char = createTestCharacter({
+            level: 10,
+            attributes: {
+                [AttributeType.Dexterity]: 20
+            },
+            statTemplate: {
+                [StatType.StartingMana]: { base: 100 },
+                [StatType.ManaCost]: { base: 50 }
+            }
+        });
+        new Battle([char], []);
+
+        Vanish.func(char);
+        expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(7); // 1 + 4 + 2 = 7
+        expect(char.isInvisible()).toBe(true);
+        expect(char.currentMana).toBe(50);
+    });
+
+    test('Vanish - 100 Dexterity', () => {
+        char = createTestCharacter({
+            level: 10,
+            attributes: {
+                [AttributeType.Dexterity]: 100
+            },
+            statTemplate: {
+                [StatType.StartingMana]: { base: 100 },
+                [StatType.ManaCost]: { base: 50 }
+            }
+        });
+        new Battle([char], []);
+
+        Vanish.func(char);
+        expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(23); // 1 + 4 + 18 = 23
+        expect(char.isInvisible()).toBe(true);
+        expect(char.currentMana).toBe(50);
+    });
 });
 
-test('Vanish - 10 Dexterity', () => {
-    char = createTestCharacter({
-        level: 10,
-        attributes: {
-            [AttributeType.Dexterity]: 10
-        },
-        statTemplate: {
-            [StatType.StartingMana]: { base: 100 },
-            [StatType.ManaCost]: { base: 50 }
-        }
-    });
-    new Battle([char], []);
-
-    Vanish.func(char);
-    expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(5); // 1 + 4 + 0 = 5
-    expect(char.isInvisible()).toBe(true);
-    expect(char.currentMana).toBe(50);
-});
-
-test('Vanish - 20 Dexterity', () => {
+describe('Vanish Description', () => {
     char = createTestCharacter({
         level: 10,
         attributes: {
             [AttributeType.Dexterity]: 20
-        },
-        statTemplate: {
-            [StatType.StartingMana]: { base: 100 },
-            [StatType.ManaCost]: { base: 50 }
         }
     });
-    new Battle([char], []);
-
-    Vanish.func(char);
-    expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(7); // 1 + 4 + 2 = 7
-    expect(char.isInvisible()).toBe(true);
-    expect(char.currentMana).toBe(50);
-});
-
-test('Vanish - 100 Dexterity', () => {
-    char = createTestCharacter({
-        level: 10,
-        attributes: {
-            [AttributeType.Dexterity]: 100
-        },
-        statTemplate: {
-            [StatType.StartingMana]: { base: 100 },
-            [StatType.ManaCost]: { base: 50 }
-        }
+    test('No Character', () => {
+        expect(Vanish.description()).toBe(
+            `Gain ${Invisible.name}, causing your next attack to be a sneak attack, dealing ${Invisible.damage} damage per stack.`
+        );
     });
-    new Battle([char], []);
-
-    Vanish.func(char);
-    expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(23); // 1 + 4 + 18 = 23
-    expect(char.isInvisible()).toBe(true);
-    expect(char.currentMana).toBe(50);
+    test('With Character', () => {
+        expect(Vanish.description(char)).toBe(
+            `Gain 23 ${Invisible.name}, causing your next attack to be a sneak attack, dealing ${Invisible.damage} damage per stack.`
+        );
+    });
 });

--- a/src/Ability/Vanish.test.ts
+++ b/src/Ability/Vanish.test.ts
@@ -13,7 +13,7 @@ test('Vanish - 0 Dexterity', () => {
     char = createTestCharacter({
         level: 10,
         attributes: {
-            [AttributeType.Dexterity]: 0
+            [AttributeType.Dexterity]: 5
         },
         statTemplate: {
             [StatType.StartingMana]: { base: 100 },
@@ -23,7 +23,7 @@ test('Vanish - 0 Dexterity', () => {
     new Battle([char], []);
 
     Vanish.func(char);
-    expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(1);
+    expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(4); // 1 + 4 - 1 = 4
     expect(char.isInvisible()).toBe(true);
     expect(char.currentMana).toBe(50);
 });
@@ -42,7 +42,7 @@ test('Vanish - 10 Dexterity', () => {
     new Battle([char], []);
 
     Vanish.func(char);
-    expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(1);
+    expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(5); // 1 + 4 + 0 = 5
     expect(char.isInvisible()).toBe(true);
     expect(char.currentMana).toBe(50);
 });
@@ -61,7 +61,7 @@ test('Vanish - 20 Dexterity', () => {
     new Battle([char], []);
 
     Vanish.func(char);
-    expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(2);
+    expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(7); // 1 + 4 + 2 = 7
     expect(char.isInvisible()).toBe(true);
     expect(char.currentMana).toBe(50);
 });
@@ -80,7 +80,7 @@ test('Vanish - 100 Dexterity', () => {
     new Battle([char], []);
 
     Vanish.func(char);
-    expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(10);
+    expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(23); // 1 + 4 + 18 = 23
     expect(char.isInvisible()).toBe(true);
     expect(char.currentMana).toBe(50);
 });

--- a/src/Ability/Vanish.ts
+++ b/src/Ability/Vanish.ts
@@ -25,7 +25,9 @@ const Vanish: Ability = {
             source: char,
             stacks
         }));
-    }
+    },
+    scaling: ['level', AttributeType.Dexterity]
+
 } as const;
 
 export default Vanish;

--- a/src/Ability/Vanish.ts
+++ b/src/Ability/Vanish.ts
@@ -1,11 +1,13 @@
 import BuffId from '../StatusEffect/types/BuffId';
 import Invisible from '../StatusEffect/Buffs/Invisible';
 import Ability from './Ability';
+import AbilityId from './AbilityId';
 
 const NAME = 'Vanish';
 const DEX_RATIO = 0.1;
 
 const Vanish: Ability = {
+    id: AbilityId.Vanish,
     name: NAME,
     description: (char) => {
         const stacks = char ? Math.max(Math.floor(char.attributes.dexterity * DEX_RATIO), 1) : null;
@@ -21,6 +23,6 @@ const Vanish: Ability = {
             stacks
         }));
     }
-};
+} as const;
 
 export default Vanish;

--- a/src/Ability/Vanish.ts
+++ b/src/Ability/Vanish.ts
@@ -2,21 +2,24 @@ import BuffId from '../StatusEffect/types/BuffId';
 import Invisible from '../StatusEffect/Buffs/Invisible';
 import Ability from './Ability';
 import AbilityId from './AbilityId';
+import AttributeType from '../Character/Attributes/AttributeType';
+import Attributes from '../Character/Attributes/Attributes';
 
 const NAME = 'Vanish';
-const DEX_RATIO = 0.1;
+const stacksPerLvl = 0.5;
+const stacksPerDex = 0.2;
 
 const Vanish: Ability = {
     id: AbilityId.Vanish,
     name: NAME,
     description: (char) => {
-        const stacks = char ? Math.max(Math.floor(char.attributes.dexterity * DEX_RATIO), 1) : null;
-        return `Gain ${stacks ?? ''}(${DEX_RATIO * 100}% DEX) ${BuffId.Invisible} stacks, causing your next attack to be a sneak attack, dealing ${Invisible.damage} damage per ${BuffId.Invisible} stack.`;
+        const stacks = char ? 1 + Math.floor(stacksPerLvl * (char.level - 1)) + Math.trunc(stacksPerDex * (char.attributes.dexterity - Attributes.DEFAULT_VALUE)) : null;
+        return `Gain ${stacks ? `${stacks} ` : ''} ${Invisible.name} stacks, causing your next attack to be a sneak attack, dealing ${Invisible.damage} damage per ${BuffId.Invisible} stack.`;
     },
     func: (char) => {
         char.useAbilityMana();
         if (char.battle) char.battle.ref.log.add(`${char.name} used ${NAME}.`);
-        const stacks = Math.max(Math.floor(char.attributes.dexterity * DEX_RATIO), 1);
+        const stacks = 1 + Math.floor(stacksPerLvl * (char.level - 1)) + Math.trunc(stacksPerDex * (char.attributes.dexterity - Attributes.DEFAULT_VALUE));
         char.statusEffectManager.add(new Invisible({
             char,
             source: char,

--- a/src/Ability/Vanish.ts
+++ b/src/Ability/Vanish.ts
@@ -1,4 +1,3 @@
-import BuffId from '../StatusEffect/types/BuffId';
 import Invisible from '../StatusEffect/Buffs/Invisible';
 import Ability from './Ability';
 import AbilityId from './AbilityId';
@@ -14,7 +13,7 @@ const Vanish: Ability = {
     name: NAME,
     description: (char) => {
         const stacks = char ? 1 + Math.floor(stacksPerLvl * (char.level - 1)) + Math.trunc(stacksPerDex * (char.attributes.dexterity - Attributes.DEFAULT_VALUE)) : null;
-        return `Gain ${stacks ? `${stacks} ` : ''} ${Invisible.name} stacks, causing your next attack to be a sneak attack, dealing ${Invisible.damage} damage per ${BuffId.Invisible} stack.`;
+        return `Gain${stacks ? ` ${stacks}` : ''} ${Invisible.name}, causing your next attack to be a sneak attack, dealing ${Invisible.damage} damage per stack.`;
     },
     func: (char) => {
         char.useAbilityMana();

--- a/src/Ability/WoundingShot.test.ts
+++ b/src/Ability/WoundingShot.test.ts
@@ -49,23 +49,40 @@ beforeEach(() => {
     new Battle([char], [target]);
 });
 
-let hitRollSpy: jest.SpyInstance;
-let critRollSpy: jest.SpyInstance;
-beforeEach(() => {
-    hitRollSpy = jest.spyOn(Character.prototype, 'hitRoll').mockReturnValue(true);
-    critRollSpy = jest.spyOn(Character, 'critRoll').mockReturnValue(true);
-});
-afterEach(() => {
-    hitRollSpy.mockRestore();
-    critRollSpy.mockRestore();
+
+describe('WoundingShot Damage and Debuff', () => {
+    let hitRollSpy: jest.SpyInstance;
+    let critRollSpy: jest.SpyInstance;
+    beforeEach(() => {
+        hitRollSpy = jest.spyOn(Character.prototype, 'hitRoll').mockReturnValue(true);
+        critRollSpy = jest.spyOn(Character, 'critRoll').mockReturnValue(true);
+    });
+    afterEach(() => {
+        hitRollSpy.mockRestore();
+        critRollSpy.mockRestore();
+    });
+
+    test('WoundingShot.func', () => {
+        WoundingShot.func(char);
+        expect(target.currentHealth).toBeCloseTo(88.75); // 100 - (5 * 1.5 * 1.5 = 11.25) = 88.75
+        expect(char.currentMana).toBe(50);
+
+        const bleedingDebuff = target.statusEffectManager.debuffs[DebuffId.Bleeding]![getCharBattleId(char)] as Bleeding;
+        expect(bleedingDebuff.stacks).toBe(3);
+        expect(bleedingDebuff.remainingDamage).toBeCloseTo(6.75); // 11.25 * 0.2 * 3
+    });
 });
 
-test('WoundingShot.func', () => {
-    WoundingShot.func(char);
-    expect(target.currentHealth).toBeCloseTo(88.75); // 100 - (5 * 1.5 * 1.5 = 11.25) = 88.75
-    expect(char.currentMana).toBe(50);
 
-    const bleedingDebuff = target.statusEffectManager.debuffs[DebuffId.Bleeding]![getCharBattleId(char)] as Bleeding;
-    expect(bleedingDebuff.stacks).toBe(3);
-    expect(bleedingDebuff.remainingDamage).toBeCloseTo(6.75); // 11.25 * 0.2 * 3
+describe('WoundingShot Description', () => {
+    test('No Character', () => {
+        expect(WoundingShot.description()).toBe(
+            'Deals damage and applies Bleed dealing 60% of the initial damage dealt over 3 turns.'
+        );
+    });
+    test('With Character', () => {
+        expect(WoundingShot.description(char)).toBe(
+            'Deals 7.5-7.5 damage and applies Bleed dealing 60% of the initial damage dealt over 3 turns.'
+        );
+    });
 });

--- a/src/Ability/WoundingShot.ts
+++ b/src/Ability/WoundingShot.ts
@@ -51,7 +51,8 @@ const WoundingShot: Ability = {
                 }));
             }
         }
-    }
+    },
+    attackType: AttackType.RangedWeapon,
 } as const;
 
 export default WoundingShot;

--- a/src/Ability/WoundingShot.ts
+++ b/src/Ability/WoundingShot.ts
@@ -2,6 +2,7 @@ import AttackType from '../types/AttackType';
 import Ability from './Ability';
 import { formatNum } from '../util';
 import Bleeding from '../StatusEffect/Debuffs/Bleeding';
+import AbilityId from './AbilityId';
 
 const NAME = 'Wounding Shot';
 const BONUS_DMG = 0.5;
@@ -9,6 +10,7 @@ const BLEED_STACKS = 3;
 const DMG_PER_TURN = 0.2;
 
 const WoundingShot: Ability = {
+    id: AbilityId.WoundingShot,
     name: NAME,
     description: (char) => {
         const damageRange = char ? char.calcDamageRange({
@@ -50,6 +52,6 @@ const WoundingShot: Ability = {
             }
         }
     }
-};
+} as const;
 
 export default WoundingShot;

--- a/src/Ability/WoundingShot.ts
+++ b/src/Ability/WoundingShot.ts
@@ -22,7 +22,7 @@ const WoundingShot: Ability = {
             weaponAttack: true,
             spellPowerRatio: char.equipment.mainHand.spellPowerRatio ? char.equipment.mainHand.spellPowerRatio * (1 + BONUS_DMG) : char.equipment.mainHand.spellPowerRatio
         }) : null;
-        return `Deals ${damageRange ? `${formatNum(damageRange.min)} - ${formatNum(damageRange.max)} ` : ''}damage and applies Bleed dealing ${formatNum(DMG_PER_TURN * BLEED_STACKS * 100)}% of the damage dealt over ${BLEED_STACKS} turns.`;
+        return `Deals ${damageRange ? `${formatNum(damageRange.min)}-${formatNum(damageRange.max)} ` : ''}damage and applies Bleed dealing ${formatNum(DMG_PER_TURN * BLEED_STACKS * 100)}% of the initial damage dealt over ${BLEED_STACKS} turns.`;
     },
     func: (char) => {
         if (char.target) {

--- a/src/Ability/abilities.ts
+++ b/src/Ability/abilities.ts
@@ -9,6 +9,7 @@ import Firebolt from './Firebolt';
 import Frostbolt from './Frostbolt';
 import SerpentSting from './SerpentSting';
 import ShieldWall from './ShieldWall';
+import Smite from './Smite';
 import Vanish from './Vanish';
 import WoundingShot from './WoundingShot';
 
@@ -19,6 +20,7 @@ const abilities: Record<AbilityId, Ability> = {
 
     // Priest
     [AbilityId.Bless]: Bless,
+    [AbilityId.Smite]: Smite,
 
     // Ranger
     [AbilityId.SerpentSting]: SerpentSting,

--- a/src/Ability/abilities.ts
+++ b/src/Ability/abilities.ts
@@ -3,8 +3,10 @@ import AbilityId from './AbilityId';
 
 import Bless from './Bless';
 import DoubleStrike from './DoubleStrike';
+import EnvenomWeapon from './EnvenomWeapon';
 import FerociousBite from './FerociousBite';
 import Firebolt from './Firebolt';
+import Frostbolt from './Frostbolt';
 import SerpentSting from './SerpentSting';
 import ShieldWall from './ShieldWall';
 import Vanish from './Vanish';
@@ -24,9 +26,11 @@ const abilities: Record<AbilityId, Ability> = {
 
     // Rogue
     [AbilityId.Vanish]: Vanish,
+    [AbilityId.EnvenomWeapon]: EnvenomWeapon,
 
     // Wizard
     [AbilityId.Firebolt]: Firebolt,
+    [AbilityId.Frostbolt]: Frostbolt,
 
     // Other
     [AbilityId.FerociousBite]: FerociousBite,

--- a/src/Ability/abilities.ts
+++ b/src/Ability/abilities.ts
@@ -5,16 +5,31 @@ import Bless from './Bless';
 import DoubleStrike from './DoubleStrike';
 import FerociousBite from './FerociousBite';
 import Firebolt from './Firebolt';
+import SerpentSting from './SerpentSting';
+import ShieldWall from './ShieldWall';
 import Vanish from './Vanish';
 import WoundingShot from './WoundingShot';
 
 const abilities: Record<AbilityId, Ability> = {
-    [AbilityId.Bless]: Bless,
+    // Fighter
     [AbilityId.DoubleStrike]: DoubleStrike,
-    [AbilityId.FerociousBite]: FerociousBite,
-    [AbilityId.Firebolt]: Firebolt,
-    [AbilityId.Vanish]: Vanish,
+    [AbilityId.ShieldWall]: ShieldWall,
+
+    // Priest
+    [AbilityId.Bless]: Bless,
+
+    // Ranger
+    [AbilityId.SerpentSting]: SerpentSting,
     [AbilityId.WoundingShot]: WoundingShot,
+
+    // Rogue
+    [AbilityId.Vanish]: Vanish,
+
+    // Wizard
+    [AbilityId.Firebolt]: Firebolt,
+
+    // Other
+    [AbilityId.FerociousBite]: FerociousBite,
 } as const;
 
 export default abilities;

--- a/src/Ability/abilities.ts
+++ b/src/Ability/abilities.ts
@@ -1,0 +1,20 @@
+import Ability from './Ability';
+import AbilityId from './AbilityId';
+
+import Bless from './Bless';
+import DoubleStrike from './DoubleStrike';
+import FerociousBite from './FerociousBite';
+import Firebolt from './Firebolt';
+import Vanish from './Vanish';
+import WoundingShot from './WoundingShot';
+
+const abilities: Record<AbilityId, Ability> = {
+    [AbilityId.Bless]: Bless,
+    [AbilityId.DoubleStrike]: DoubleStrike,
+    [AbilityId.FerociousBite]: FerociousBite,
+    [AbilityId.Firebolt]: Firebolt,
+    [AbilityId.Vanish]: Vanish,
+    [AbilityId.WoundingShot]: WoundingShot,
+} as const;
+
+export default abilities;

--- a/src/Character/Character.test.ts
+++ b/src/Character/Character.test.ts
@@ -12,6 +12,8 @@ import { EquipSlot } from '../Equipment/Equipment';
 import NumberRange from '../NumberRange';
 import HitType from '../types/HitType';
 import { LineType } from '../Battle/Log';
+import Stunned from '../StatusEffect/Debuffs/Stunned';
+import Frozen from '../StatusEffect/Debuffs/Frozen';
 
 describe('calcCritDamage', () => {
     // 10 DMG
@@ -2188,5 +2190,48 @@ describe('setTarget', () => {
         mathRandomSpy.mockReturnValue(0.99);
         left1.setTarget();
         expect(left1.target).toBe(right1);
+    });
+});
+
+describe('isCrowdControlled', () => {
+    let char: Character;
+
+    beforeEach(() => {
+        char = createTestCharacter({});
+        new Battle([char], []);
+    });
+
+    test('No crowd control', () => {
+        expect(char.isCrowdControlled()).toBeFalsy();
+    });
+
+    describe('Stunned', () => {
+        test('0 stacks', () => {
+            char.statusEffectManager.add(new Stunned({ char, source: char, stacks: 0 }));
+            expect(char.isCrowdControlled()).toBeFalsy();
+        });
+        test('1 stack', () => {
+            char.statusEffectManager.add(new Stunned({ char, source: char, stacks: 1 }));
+            expect(char.isCrowdControlled()).toBeTruthy();
+        });
+        test('10 stacks', () => {
+            char.statusEffectManager.add(new Stunned({ char, source: char, stacks: 10 }));
+            expect(char.isCrowdControlled()).toBeTruthy();
+        });
+    });
+
+    describe('Frozen', () => {
+        test('0 stacks', () => {
+            char.statusEffectManager.add(new Frozen({ char, source: char, stacks: 0 }));
+            expect(char.isCrowdControlled()).toBeFalsy();
+        });
+        test('1 stack', () => {
+            char.statusEffectManager.add(new Frozen({ char, source: char, stacks: 1 }));
+            expect(char.isCrowdControlled()).toBeTruthy();
+        });
+        test('10 stacks', () => {
+            char.statusEffectManager.add(new Frozen({ char, source: char, stacks: 10 }));
+            expect(char.isCrowdControlled()).toBeTruthy();
+        });
     });
 });

--- a/src/Character/Character.ts
+++ b/src/Character/Character.ts
@@ -9,7 +9,8 @@ import NumberRange, { numberRoll } from '../NumberRange';
 import Ability from '../Ability/Ability';
 import { StatTemplate } from './Stats/StatTemplate';
 import Invisible from '../StatusEffect/Buffs/Invisible';
-import { ClassName, Classes } from './Classes/classes';
+import classes from './Classes/classes';
+import ClassName from './Classes/ClassName';
 import BuffId from '../StatusEffect/types/BuffId';
 import StatType from './Stats/StatType';
 import Attributes from './Attributes/Attributes';
@@ -63,7 +64,7 @@ export default class Character {
         // Attributes
         this._attributes = new Attributes(attributes, this._equipment);
         if (className) {
-            for (const [attr, val] of Object.entries(Classes[className].attributes)) {
+            for (const [attr, val] of Object.entries(classes[className].attributes)) {
                 this._attributes.addBonus(attr as AttributeType, val);
             }
         }
@@ -76,7 +77,7 @@ export default class Character {
             level
         });
 
-        this._ability = ability ?? (className ? Classes[className].ability : null);
+        this._ability = ability ?? null;
         this._currentHealth = options?.currHealthPc !== undefined ? Math.ceil(this.stats.maxHealth * options.currHealthPc) : this.stats.maxHealth;
         this._currentMana = this.stats.getStat(StatType.StartingMana);
 

--- a/src/Character/Character.ts
+++ b/src/Character/Character.ts
@@ -20,6 +20,7 @@ import { type Weapon } from '../Equipment/Weapon/Weapon';
 import { createPet, PetId } from './Pet';
 import AttributeType from './Attributes/AttributeType';
 import { NpcId } from '../npc/NPC';
+import DebuffId from '../StatusEffect/types/DebuffId';
 
 // Crit chance, crit dmg, Accuracy, dodge chance, mana regen, mana on hit (one-hand vs two-hand)
 export default class Character {
@@ -226,16 +227,19 @@ export default class Character {
 
     doTurn(): void {
         this.statusEffectManager.turnStart();
-        if (this.equipment.potion && this.equipment.potion.charges > 0 && this.currentHealth <= this.stats.maxHealth / 2) {
-            this.usePotion();
-        }
 
-        this.setTarget();
-        if (this.ability && this.currentMana >= this.stats.getStat(StatType.ManaCost)) {
-            this.ability.func(this);
-        }
-        else {
-            this.turnAttack();
+        if (!this.isCrowdControlled()) {
+            if (this.equipment.potion && this.equipment.potion.charges > 0 && this.currentHealth <= this.stats.maxHealth / 2) {
+                this.usePotion();
+            }
+
+            this.setTarget();
+            if (this.ability && this.currentMana >= this.stats.getStat(StatType.ManaCost)) {
+                this.ability.func(this);
+            }
+            else {
+                this.turnAttack();
+            }
         }
 
         this.addMana(this.stats.getStat(StatType.ManaRegen));
@@ -447,5 +451,12 @@ export default class Character {
 
     static calcDamageAfterBlock(damage: number, blockPower: number) {
         return Math.max(damage - Math.max(blockPower, 0), 0);
+    }
+
+    isCrowdControlled(): boolean {
+        if (this.statusEffectManager.getDebuffStacks(DebuffId.Frozen) > 0 ||
+            this.statusEffectManager.getDebuffStacks(DebuffId.Stunned) > 0)
+            return true;
+        return false;
     }
 }

--- a/src/Character/Character.ts
+++ b/src/Character/Character.ts
@@ -347,7 +347,7 @@ export default class Character {
             }
         }
 
-        this.statusEffectManager.onAttack(hit);
+        this.statusEffectManager.onAttack(hit, target);
 
         // Deal thorns damage to this Character if target was hit
         if (hit && target.stats.getStat(StatType.Thorns) > 0) {

--- a/src/Character/Classes/Class.ts
+++ b/src/Character/Classes/Class.ts
@@ -7,7 +7,7 @@ type Class = {
     description: string;
     attributes: BaseAttributes;
     stats: BaseStats;
-    ability: Ability;
-}
+    abilities: Ability[];
+};
 
 export default Class;

--- a/src/Character/Classes/Class.ts
+++ b/src/Character/Classes/Class.ts
@@ -7,7 +7,7 @@ type Class = {
     description: string;
     attributes: BaseAttributes;
     stats: BaseStats;
-    abilities: Ability[];
+    abilities: readonly Ability[];
 };
 
 export default Class;

--- a/src/Character/Classes/ClassName.ts
+++ b/src/Character/Classes/ClassName.ts
@@ -1,0 +1,9 @@
+enum ClassName {
+    Fighter = 'Fighter',
+    Priest = 'Priest',
+    Ranger = 'Ranger',
+    Rogue = 'Rogue',
+    Wizard = 'Wizard',
+}
+
+export default ClassName;

--- a/src/Character/Classes/Fighter.ts
+++ b/src/Character/Classes/Fighter.ts
@@ -1,4 +1,5 @@
 import DoubleStrike from '../../Ability/DoubleStrike';
+import ShieldWall from '../../Ability/ShieldWall';
 import AttributeType from '../Attributes/AttributeType';
 import Class from './Class';
 
@@ -10,7 +11,7 @@ const Fighter: Class = {
         [AttributeType.Constitution]: 5
     },
     stats: {},
-    ability: DoubleStrike
+    abilities: [DoubleStrike, ShieldWall]
 } as const;
 
 export default Fighter;

--- a/src/Character/Classes/Priest.ts
+++ b/src/Character/Classes/Priest.ts
@@ -1,4 +1,5 @@
 import Bless from '../../Ability/Bless';
+import Smite from '../../Ability/Smite';
 import AttributeType from '../Attributes/AttributeType';
 import Class from './Class';
 
@@ -10,7 +11,7 @@ const Priest: Class = {
         [AttributeType.Wisdom]: 5
     },
     stats: {},
-    abilities: [Bless]
+    abilities: [Bless, Smite]
 } as const;
 
 export default Priest;

--- a/src/Character/Classes/Priest.ts
+++ b/src/Character/Classes/Priest.ts
@@ -10,7 +10,7 @@ const Priest: Class = {
         [AttributeType.Wisdom]: 5
     },
     stats: {},
-    ability: Bless
+    abilities: [Bless]
 } as const;
 
 export default Priest;

--- a/src/Character/Classes/Ranger.ts
+++ b/src/Character/Classes/Ranger.ts
@@ -10,7 +10,7 @@ const Ranger: Class = {
         [AttributeType.Perception]: 5,
     },
     stats: {},
-    ability: WoundingShot
+    abilities: [WoundingShot]
 } as const;
 
 export default Ranger;

--- a/src/Character/Classes/Ranger.ts
+++ b/src/Character/Classes/Ranger.ts
@@ -1,3 +1,4 @@
+import SerpentSting from '../../Ability/SerpentSting';
 import WoundingShot from '../../Ability/WoundingShot';
 import AttributeType from '../Attributes/AttributeType';
 import Class from './Class';
@@ -10,7 +11,7 @@ const Ranger: Class = {
         [AttributeType.Perception]: 5,
     },
     stats: {},
-    abilities: [WoundingShot]
+    abilities: [SerpentSting, WoundingShot]
 } as const;
 
 export default Ranger;

--- a/src/Character/Classes/Rogue.ts
+++ b/src/Character/Classes/Rogue.ts
@@ -1,3 +1,4 @@
+import EnvenomWeapon from '../../Ability/EnvenomWeapon';
 import Vanish from '../../Ability/Vanish';
 import AttributeType from '../Attributes/AttributeType';
 import Class from './Class';
@@ -10,7 +11,7 @@ const Rogue: Class = {
         [AttributeType.Dexterity]: 5
     },
     stats: {},
-    abilities: [Vanish]
+    abilities: [EnvenomWeapon, Vanish]
 } as const;
 
 export default Rogue;

--- a/src/Character/Classes/Rogue.ts
+++ b/src/Character/Classes/Rogue.ts
@@ -10,7 +10,7 @@ const Rogue: Class = {
         [AttributeType.Dexterity]: 5
     },
     stats: {},
-    ability: Vanish
+    abilities: [Vanish]
 } as const;
 
 export default Rogue;

--- a/src/Character/Classes/Wizard.ts
+++ b/src/Character/Classes/Wizard.ts
@@ -10,7 +10,7 @@ const Wizard: Class = {
         [AttributeType.Wisdom]: 5
     },
     stats: {},
-    ability: Firebolt
+    abilities: [Firebolt]
 } as const;
 
 export default Wizard;

--- a/src/Character/Classes/Wizard.ts
+++ b/src/Character/Classes/Wizard.ts
@@ -1,4 +1,5 @@
 import Firebolt from '../../Ability/Firebolt';
+import Frostbolt from '../../Ability/Frostbolt';
 import AttributeType from '../Attributes/AttributeType';
 import Class from './Class';
 
@@ -10,7 +11,7 @@ const Wizard: Class = {
         [AttributeType.Wisdom]: 5
     },
     stats: {},
-    abilities: [Firebolt]
+    abilities: [Firebolt, Frostbolt]
 } as const;
 
 export default Wizard;

--- a/src/Character/Classes/classLoadouts.ts
+++ b/src/Character/Classes/classLoadouts.ts
@@ -8,9 +8,9 @@ import { armour } from '../../Equipment/Armour';
 import { EquipmentImport, EquipSlot } from '../../Equipment/Equipment';
 import { shields } from '../../Equipment/Shield';
 import { weapons } from '../../Equipment/Weapon/weapons';
-import { ClassName } from './classes';
+import ClassName from './ClassName';
 
-const startingAbility: { [name in ClassName]: Ability } = {
+const startingAbility: Record<ClassName, Ability> = {
     [ClassName.Fighter]: DoubleStrike,
     [ClassName.Priest]: Bless,
     [ClassName.Ranger]: WoundingShot,
@@ -18,7 +18,7 @@ const startingAbility: { [name in ClassName]: Ability } = {
     [ClassName.Wizard]: Firebolt
 };
 
-const startingEquipment: { [name in ClassName]: EquipmentImport } = {
+const startingEquipment: Record<ClassName, EquipmentImport> = {
     [ClassName.Fighter]: {
         [EquipSlot.MainHand]: weapons.longsword0,
         [EquipSlot.OffHand]: shields.buckler0,

--- a/src/Character/Classes/classes.ts
+++ b/src/Character/Classes/classes.ts
@@ -1,18 +1,11 @@
+import ClassName from './ClassName';
 import Fighter from './Fighter';
 import Priest from './Priest';
 import Ranger from './Ranger';
 import Rogue from './Rogue';
 import Wizard from './Wizard';
 
-enum ClassName {
-    Fighter = 'Fighter',
-    Priest = 'Priest',
-    Ranger = 'Ranger',
-    Rogue = 'Rogue',
-    Wizard = 'Wizard',
-}
-
-const Classes = {
+const classes = {
     [ClassName.Fighter]: Fighter,
     [ClassName.Priest]: Priest,
     [ClassName.Ranger]: Ranger,
@@ -20,4 +13,4 @@ const Classes = {
     [ClassName.Wizard]: Wizard,
 } as const;
 
-export { Classes, ClassName };
+export default classes;

--- a/src/Equipment/Shield.ts
+++ b/src/Equipment/Shield.ts
@@ -127,7 +127,7 @@ const shields: { [id in ShieldId]: Shield } = {
         stats: {
             [StatType.BlockChance]: 30,
             [StatType.BlockPower]: 6,
-            [StatType.Thorns]: 3,
+            [StatType.Thorns]: 4,
         }
     },
     spikedShield3: {
@@ -140,7 +140,7 @@ const shields: { [id in ShieldId]: Shield } = {
         stats: {
             [StatType.BlockChance]: 30,
             [StatType.BlockPower]: 8,
-            [StatType.Thorns]: 4,
+            [StatType.Thorns]: 7,
         }
     },
     spikedShield4: {
@@ -153,7 +153,7 @@ const shields: { [id in ShieldId]: Shield } = {
         stats: {
             [StatType.BlockChance]: 30,
             [StatType.BlockPower]: 10,
-            [StatType.Thorns]: 5,
+            [StatType.Thorns]: 11,
         }
     },
     spikedShield5: {
@@ -166,7 +166,7 @@ const shields: { [id in ShieldId]: Shield } = {
         stats: {
             [StatType.BlockChance]: 30,
             [StatType.BlockPower]: 12,
-            [StatType.Thorns]: 6,
+            [StatType.Thorns]: 16,
         }
     },
     towerShield0: {

--- a/src/StatusEffect/Buffs/Blessed.ts
+++ b/src/StatusEffect/Buffs/Blessed.ts
@@ -7,6 +7,7 @@ import StatusEffectCtorArgs from '../types/StatusEffectCtorArgs';
 
 export default class Blessed extends Buff implements StatsInterface {
     id = BuffId.Blessed;
+    name = 'Blessed';
 
     static baseAccuracy = 5;
     static accuracyPerLvl = 0.5;

--- a/src/StatusEffect/Buffs/Blessed.ts
+++ b/src/StatusEffect/Buffs/Blessed.ts
@@ -48,6 +48,7 @@ export default class Blessed extends Buff implements StatsInterface {
     onTurnStart() { }
     onTurnEnd() { }
     onAttack() { }
+    onAttacked() { }
 
     onSourceTurnStart() {
         this.stacks -= 1;

--- a/src/StatusEffect/Buffs/EnvenomWeapon.test.ts
+++ b/src/StatusEffect/Buffs/EnvenomWeapon.test.ts
@@ -1,0 +1,52 @@
+import Battle from '../../Battle/Battle';
+import Character from '../../Character/Character';
+import { createTestCharacter } from '../../tests/util';
+import { getCharBattleId } from '../../util';
+import BuffId from '../types/BuffId';
+import DebuffId from '../types/DebuffId';
+import EnvenomWeapon from './EnvenomWeapon';
+
+let char: Character;
+let target: Character;
+
+beforeEach(() => {
+    char = createTestCharacter({});
+    target = createTestCharacter({});
+    new Battle([char], [target]);
+});
+
+
+test('0 stacks', () => {
+    char.statusEffectManager.add(new EnvenomWeapon({
+        char,
+        source: char,
+        stacks: 0
+    }));
+    expect(char.statusEffectManager.buffs[BuffId.EnvenomWeapon]).toBeUndefined();
+});
+
+test('1 stack', () => {
+    char.statusEffectManager.add(new EnvenomWeapon({
+        char,
+        source: char,
+        stacks: 1
+    }));
+    expect(char.statusEffectManager.buffs[BuffId.EnvenomWeapon]![getCharBattleId(char)].stacks).toBe(1);
+
+    char.statusEffectManager.onAttack(true, target);
+    expect(char.statusEffectManager.buffs[BuffId.EnvenomWeapon]).toStrictEqual({});
+    expect(target.statusEffectManager.debuffs[DebuffId.Poisoned]![getCharBattleId(char)].stacks).toBe(EnvenomWeapon.POISONED_STACKS);
+});
+
+test('10 stack', () => {
+    char.statusEffectManager.add(new EnvenomWeapon({
+        char,
+        source: char,
+        stacks: 10
+    }));
+    expect(char.statusEffectManager.buffs[BuffId.EnvenomWeapon]![getCharBattleId(char)].stacks).toBe(10);
+
+    char.statusEffectManager.onAttack(true, target);
+    expect(char.statusEffectManager.buffs[BuffId.EnvenomWeapon]![getCharBattleId(char)].stacks).toBe(9);
+    expect(target.statusEffectManager.debuffs[DebuffId.Poisoned]![getCharBattleId(char)].stacks).toBe(EnvenomWeapon.POISONED_STACKS);
+});

--- a/src/StatusEffect/Buffs/EnvenomWeapon.ts
+++ b/src/StatusEffect/Buffs/EnvenomWeapon.ts
@@ -1,0 +1,33 @@
+import Character from '../../Character/Character';
+import Buff from '../Buff';
+import Poisoned from '../Debuffs/Poisoned';
+import BuffId from '../types/BuffId';
+
+export default class EnvenomWeapon extends Buff {
+    id = BuffId.EnvenomWeapon;
+    name = 'Envenom Weapon';
+
+    static POISONED_STACKS = 2;
+
+    onApply() { }
+    onExpire() { }
+
+    onTurnStart() { }
+    onTurnEnd() { }
+    onAttack(hit: boolean, target: Character) {
+        if (hit) {
+            this.stacks -= 1;
+            target.statusEffectManager.add(new Poisoned({
+                char: target,
+                source: this.char,
+                stacks: EnvenomWeapon.POISONED_STACKS
+            }));
+            if (this.stacks <= 0) this.manager.removeBuff(this.id, this.source);
+        }
+
+    }
+    onAttacked() { }
+
+    onSourceTurnStart() { }
+    onSourceTurnEnd() { }
+}

--- a/src/StatusEffect/Buffs/Invisible.test.ts
+++ b/src/StatusEffect/Buffs/Invisible.test.ts
@@ -34,7 +34,7 @@ describe('Invisible - 1 source', () => {
         }));
         expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(1);
 
-        char.statusEffectManager.onAttack(true);
+        char.statusEffectManager.onAttack(true, char);
         expect(char.statusEffectManager.buffs[BuffId.Invisible]).toStrictEqual({});
     });
 
@@ -46,7 +46,7 @@ describe('Invisible - 1 source', () => {
         }));
         expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(10);
 
-        char.statusEffectManager.onAttack(true);
+        char.statusEffectManager.onAttack(true, char);
         expect(char.statusEffectManager.buffs[BuffId.Invisible]).toStrictEqual({});
     });
 
@@ -58,7 +58,7 @@ describe('Invisible - 1 source', () => {
         }));
         expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(100);
 
-        char.statusEffectManager.onAttack(true);
+        char.statusEffectManager.onAttack(true, char);
         expect(char.statusEffectManager.buffs[BuffId.Invisible]).toStrictEqual({});
     });
 });
@@ -78,7 +78,7 @@ describe('Invisible - 2 sources', () => {
         expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(1);
         expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(source1)].stacks).toBe(1);
 
-        char.statusEffectManager.onAttack(true);
+        char.statusEffectManager.onAttack(true, char);
         expect(char.statusEffectManager.buffs[BuffId.Invisible]).toStrictEqual({});
     });
 
@@ -96,7 +96,7 @@ describe('Invisible - 2 sources', () => {
         expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(char)].stacks).toBe(10);
         expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(source1)].stacks).toBe(10);
 
-        char.statusEffectManager.onAttack(true);
+        char.statusEffectManager.onAttack(true, char);
         expect(char.statusEffectManager.buffs[BuffId.Invisible]).toStrictEqual({});
     });
 });
@@ -122,7 +122,7 @@ describe('Invisible - 3 sources', () => {
         expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(source1)].stacks).toBe(1);
         expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(source2)].stacks).toBe(1);
 
-        char.statusEffectManager.onAttack(true);
+        char.statusEffectManager.onAttack(true, char);
         expect(char.statusEffectManager.buffs[BuffId.Invisible]).toStrictEqual({});
     });
 
@@ -146,7 +146,7 @@ describe('Invisible - 3 sources', () => {
         expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(source1)].stacks).toBe(10);
         expect(char.statusEffectManager.buffs[BuffId.Invisible]![getCharBattleId(source2)].stacks).toBe(10);
 
-        char.statusEffectManager.onAttack(true);
+        char.statusEffectManager.onAttack(true, char);
         expect(char.statusEffectManager.buffs[BuffId.Invisible]).toStrictEqual({});
     });
 });

--- a/src/StatusEffect/Buffs/Invisible.ts
+++ b/src/StatusEffect/Buffs/Invisible.ts
@@ -3,6 +3,7 @@ import BuffId from '../types/BuffId';
 
 export default class Invisible extends Buff {
     id = BuffId.Invisible;
+    name = 'Invisible';
 
     static damage = 4;
 

--- a/src/StatusEffect/Buffs/Invisible.ts
+++ b/src/StatusEffect/Buffs/Invisible.ts
@@ -15,6 +15,7 @@ export default class Invisible extends Buff {
     onAttack() {
         this.manager.removeBuff(this.id, this.source);
     }
+    onAttacked() { }
 
     onSourceTurnStart() { }
     onSourceTurnEnd() { }

--- a/src/StatusEffect/Buffs/ShieldWall.test.ts
+++ b/src/StatusEffect/Buffs/ShieldWall.test.ts
@@ -1,0 +1,69 @@
+import ShieldWall from './ShieldWall';
+import BuffId from '../types/BuffId';
+import StatType from '../../Character/Stats/StatType';
+import Character from '../../Character/Character';
+import AttributeType from '../../Character/Attributes/AttributeType';
+import { createTestCharacter } from '../../tests/util';
+import { getCharBattleId } from '../../util';
+import Attributes from '../../Character/Attributes/Attributes';
+import Battle from '../../Battle/Battle';
+
+let char: Character;
+
+const level = 5;
+const strength = 20;
+const blockChance = ShieldWall.blockChanceBase + ShieldWall.blockChancePerLvl * (level - 1) + ShieldWall.blockChancePerStrength * (strength - Attributes.DEFAULT_VALUE);
+const thorns = ShieldWall.thornsBase + ShieldWall.thornsPerLvl * (level - 1) + ShieldWall.thornsPerStrength * (strength - Attributes.DEFAULT_VALUE);
+
+beforeEach(() => {
+    char = createTestCharacter({
+        level: level,
+        attributes: {
+            [AttributeType.Strength]: strength
+        },
+        statTemplate: {
+            [StatType.BlockChance]: { base: 0, perLvl: 0 },
+            [StatType.Thorns]: { base: 0, perLvl: 0 },
+        }
+    });
+    new Battle([char], []);
+});
+
+test('calcBlockChance', () => {
+    expect(ShieldWall.calcBlockChance(level, strength)).toBeCloseTo(blockChance);
+});
+
+test('calcThorns', () => {
+    expect(ShieldWall.calcThorns(level, strength)).toBeCloseTo(thorns);
+});
+
+test('Shield Wall - 1 source, 1 stack', () => {
+    char.statusEffectManager.add(new ShieldWall({
+        char,
+        source: char,
+        stacks: 1
+    }));
+    expect(char.statusEffectManager.buffs[BuffId.ShieldWall]![getCharBattleId(char)].stacks).toBe(1);
+    expect(char.stats.getStat(StatType.BlockChance)).toBeCloseTo(blockChance);
+    expect(char.stats.getStat(StatType.Thorns)).toBeCloseTo(thorns);
+
+    char.statusEffectManager.turnStart();
+    expect(char.stats.getStat(StatType.BlockChance)).toBeCloseTo(0);
+    expect(char.stats.getStat(StatType.Thorns)).toBeCloseTo(0);
+});
+
+test('Shield Wall - 1 source, 3 stacks', () => {
+    char.statusEffectManager.add(new ShieldWall({
+        char,
+        source: char,
+        stacks: 3
+    }));
+    expect(char.statusEffectManager.buffs[BuffId.ShieldWall]![getCharBattleId(char)].stacks).toBe(3);
+    expect(char.stats.getStat(StatType.BlockChance)).toBeCloseTo(blockChance);
+    expect(char.stats.getStat(StatType.Thorns)).toBeCloseTo(thorns);
+
+    char.statusEffectManager.turnStart();
+    expect(char.statusEffectManager.buffs[BuffId.ShieldWall]![getCharBattleId(char)].stacks).toBe(2);
+    expect(char.stats.getStat(StatType.BlockChance)).toBeCloseTo(blockChance);
+    expect(char.stats.getStat(StatType.Thorns)).toBeCloseTo(thorns);
+});

--- a/src/StatusEffect/Buffs/ShieldWall.ts
+++ b/src/StatusEffect/Buffs/ShieldWall.ts
@@ -1,0 +1,58 @@
+import StatType from '../../Character/Stats/StatType';
+import Buff from '../Buff';
+import BuffId from '../types/BuffId';
+import StatsInterface, { StatsInterfaceType } from '../interface/StatsInterface';
+import Attributes from '../../Character/Attributes/Attributes';
+import StatusEffectCtorArgs from '../types/StatusEffectCtorArgs';
+
+export default class ShieldWall extends Buff implements StatsInterface {
+    id = BuffId.ShieldWall;
+    name = 'Shield Wall';
+
+    static blockChanceBase = 10;
+    static blockChancePerLvl = 1;
+    static blockChancePerStrength = 0.2;
+
+    static thornsBase = 2;
+    static thornsPerLvl = 1;
+    static thornsPerStrength = 0.2;
+
+    stats: StatsInterfaceType;
+
+    constructor(args: StatusEffectCtorArgs) {
+        super(args);
+        this.stats = {
+            [StatType.BlockChance]: ShieldWall.calcBlockChance(this.source.level, this.source.attributes.strength),
+            [StatType.Thorns]: ShieldWall.calcThorns(this.source.level, this.source.attributes.strength),
+        };
+    }
+
+    static calcBlockChance(level: number, strength: number): number {
+        const perLvl = ShieldWall.blockChancePerLvl * (level - 1);
+        const perStrength = ShieldWall.blockChancePerStrength * (strength - Attributes.DEFAULT_VALUE);
+        console.log('calcBlockChance', ShieldWall.blockChanceBase, perLvl, perStrength, ShieldWall.blockChanceBase + perLvl + perStrength);
+        return ShieldWall.blockChanceBase + perLvl + perStrength;
+    }
+    static calcThorns(level: number, strength: number): number {
+        const perLvl = ShieldWall.thornsPerLvl * (level - 1);
+        const perStrength = ShieldWall.thornsPerStrength * (strength - Attributes.DEFAULT_VALUE);
+        return ShieldWall.thornsBase + perLvl + perStrength;
+    }
+
+    onApply() {
+        this.char.stats.addStatusEffectStats(this.stats);
+    }
+    onExpire() {
+        this.char.stats.removeStatusEffectStats(this.stats);
+    }
+
+    onTurnStart() { }
+    onTurnEnd() { }
+    onAttack() { }
+
+    onSourceTurnStart() {
+        this.stacks -= 1;
+        if (this.stacks <= 0) this.manager.removeBuff(this.id, this.source);
+    }
+    onSourceTurnEnd() { }
+}

--- a/src/StatusEffect/Buffs/ShieldWall.ts
+++ b/src/StatusEffect/Buffs/ShieldWall.ts
@@ -49,6 +49,7 @@ export default class ShieldWall extends Buff implements StatsInterface {
     onTurnStart() { }
     onTurnEnd() { }
     onAttack() { }
+    onAttacked() { }
 
     onSourceTurnStart() {
         this.stacks -= 1;

--- a/src/StatusEffect/Buffs/ShieldWall.ts
+++ b/src/StatusEffect/Buffs/ShieldWall.ts
@@ -30,7 +30,6 @@ export default class ShieldWall extends Buff implements StatsInterface {
     static calcBlockChance(level: number, strength: number): number {
         const perLvl = ShieldWall.blockChancePerLvl * (level - 1);
         const perStrength = ShieldWall.blockChancePerStrength * (strength - Attributes.DEFAULT_VALUE);
-        console.log('calcBlockChance', ShieldWall.blockChanceBase, perLvl, perStrength, ShieldWall.blockChanceBase + perLvl + perStrength);
         return ShieldWall.blockChanceBase + perLvl + perStrength;
     }
     static calcThorns(level: number, strength: number): number {

--- a/src/StatusEffect/Debuffs/Bleeding.ts
+++ b/src/StatusEffect/Debuffs/Bleeding.ts
@@ -6,6 +6,7 @@ import StatusEffectCtorArgs from '../types/StatusEffectCtorArgs';
 
 export default class Bleeding extends Debuff implements RemainingDamage, DamageTaken {
     id = DebuffId.Bleeding;
+    name = 'Bleeding';
 
     _remainingDamage: number;
 

--- a/src/StatusEffect/Debuffs/Bleeding.ts
+++ b/src/StatusEffect/Debuffs/Bleeding.ts
@@ -54,6 +54,7 @@ export default class Bleeding extends Debuff implements RemainingDamage, DamageT
         if (this.stacks <= 0) this.manager.removeDebuff(this.id, this.source);
     }
     onAttack() { }
+    onAttacked() { }
 
     onSourceTurnStart() { }
     onSourceTurnEnd() { }

--- a/src/StatusEffect/Debuffs/Burning.ts
+++ b/src/StatusEffect/Debuffs/Burning.ts
@@ -36,6 +36,7 @@ export default class Burning extends Debuff implements DamageTaken {
         if (this.stacks <= 0) this.manager.removeDebuff(this.id, this.source);
     }
     onAttack() { }
+    onAttacked() { }
 
     onSourceTurnStart() { }
     onSourceTurnEnd() { }

--- a/src/StatusEffect/Debuffs/Burning.ts
+++ b/src/StatusEffect/Debuffs/Burning.ts
@@ -5,6 +5,7 @@ import DebuffId from '../types/DebuffId';
 
 export default class Burning extends Debuff implements DamageTaken {
     id = DebuffId.Burning;
+    name = 'Burning';
 
     static baseDamage = 1;
     static spellPowerRatio = 0.2;

--- a/src/StatusEffect/Debuffs/Frozen.ts
+++ b/src/StatusEffect/Debuffs/Frozen.ts
@@ -10,7 +10,10 @@ export default class Frozen extends Debuff {
     onExpire() { }
 
     onTurnStart() { }
-    onTurnEnd() { }
+    onTurnEnd() {
+        this.stacks -= 1;
+        if (this.stacks <= 0) this.manager.removeDebuff(this.id, this.source);
+    }
     onAttack() { }
 
     onSourceTurnStart() { }

--- a/src/StatusEffect/Debuffs/Frozen.ts
+++ b/src/StatusEffect/Debuffs/Frozen.ts
@@ -4,6 +4,7 @@ import DebuffId from '../types/DebuffId';
 // TODO: skip turn on turn start
 export default class Frozen extends Debuff {
     id = DebuffId.Frozen;
+    name = 'Frozen';
 
     onApply() { }
     onExpire() { }

--- a/src/StatusEffect/Debuffs/Frozen.ts
+++ b/src/StatusEffect/Debuffs/Frozen.ts
@@ -15,6 +15,7 @@ export default class Frozen extends Debuff {
         if (this.stacks <= 0) this.manager.removeDebuff(this.id, this.source);
     }
     onAttack() { }
+    onAttacked() { }
 
     onSourceTurnStart() { }
     onSourceTurnEnd() { }

--- a/src/StatusEffect/Debuffs/Poisoned.ts
+++ b/src/StatusEffect/Debuffs/Poisoned.ts
@@ -38,6 +38,7 @@ export default class Poisoned extends Debuff implements DamageTaken {
         if (this.stacks <= 0) this.manager.removeDebuff(this.id, this.source);
     }
     onAttack() { }
+    onAttacked() { }
 
     onSourceTurnStart() { }
     onSourceTurnEnd() { }

--- a/src/StatusEffect/Debuffs/Poisoned.ts
+++ b/src/StatusEffect/Debuffs/Poisoned.ts
@@ -5,6 +5,7 @@ import DebuffId from '../types/DebuffId';
 
 export default class Poisoned extends Debuff implements DamageTaken {
     id = DebuffId.Poisoned;
+    name = 'Poisoned';
 
     static baseDamage = 1;
     static healthDamagePercent = 0.01;

--- a/src/StatusEffect/Debuffs/Smote.test.ts
+++ b/src/StatusEffect/Debuffs/Smote.test.ts
@@ -1,0 +1,218 @@
+import Battle from '../../Battle/Battle';
+import Attributes from '../../Character/Attributes/Attributes';
+import AttributeType from '../../Character/Attributes/AttributeType';
+import Character from '../../Character/Character';
+import StatType from '../../Character/Stats/StatType';
+import { createTestCharacter } from '../../tests/util';
+import { getCharBattleId } from '../../util';
+import DebuffId from '../types/DebuffId';
+import Smote from './Smote';
+
+let char: Character;
+let source1: Character;
+let source2: Character;
+
+const charLevel = 5;
+const charWisdom = 20;
+const charAccuracy = -(Smote.baseAccuracy + Smote.accuracyPerLvl * (charLevel - 1) + Smote.accuracyPerWisdom * (charWisdom - Attributes.DEFAULT_VALUE));
+const charDamage = -(Smote.baseDamage + Smote.damagePerLvl * (charLevel - 1) + Smote.damagePerWisdom * (charWisdom - Attributes.DEFAULT_VALUE));
+
+const source1Level = 1;
+const source1Wisdom = 5;
+const source1Accuracy = -(Smote.baseAccuracy + Smote.accuracyPerLvl * (source1Level - 1) + Smote.accuracyPerWisdom * (source1Wisdom - Attributes.DEFAULT_VALUE));
+const source1Damage = -(Smote.baseDamage + Smote.damagePerLvl * (source1Level - 1) + Smote.damagePerWisdom * (source1Wisdom - Attributes.DEFAULT_VALUE));
+
+const source2Level = 10;
+const source2Wisdom = 15;
+const source2Accuracy = -(Smote.baseAccuracy + Smote.accuracyPerLvl * (source2Level - 1) + Smote.accuracyPerWisdom * (source2Wisdom - Attributes.DEFAULT_VALUE));
+const source2Damage = -(Smote.baseDamage + Smote.damagePerLvl * (source2Level - 1) + Smote.damagePerWisdom * (source2Wisdom - Attributes.DEFAULT_VALUE));
+
+
+beforeEach(() => {
+    char = createTestCharacter({
+        level: charLevel,
+        attributes: {
+            [AttributeType.Wisdom]: charWisdom
+        },
+        statTemplate: {
+            [StatType.Damage]: { base: 0, perLvl: 0 },
+            [StatType.Accuracy]: { base: 0, perLvl: 0 },
+        }
+    });
+
+    source1 = createTestCharacter({
+        level: source1Level,
+        attributes: {
+            [AttributeType.Wisdom]: source1Wisdom
+        }
+    });
+
+    source2 = createTestCharacter({
+        level: source2Level,
+        attributes: {
+            [AttributeType.Wisdom]: source2Wisdom
+        }
+    });
+
+    new Battle([char, source1, source2], []);
+});
+
+test('Smote - 1 source, 1 stack', () => {
+    char.statusEffectManager.add(new Smote({
+        char,
+        source: char,
+        stacks: 1
+    }));
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(char)].stacks).toBe(1);
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(charDamage);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(charAccuracy);
+
+    char.statusEffectManager.turnEnd();
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(0);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(0);
+});
+
+test('Smote - 1 source, 3 stacks', () => {
+    char.statusEffectManager.add(new Smote({
+        char,
+        source: char,
+        stacks: 3
+    }));
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(char)].stacks).toBe(3);
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(charDamage);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(charAccuracy);
+
+    // 2 stacks
+    char.statusEffectManager.turnEnd();
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(char)].stacks).toBe(2);
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(charDamage);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(charAccuracy);
+
+    // 0 stacks
+    char.statusEffectManager.turnEnd();
+    char.statusEffectManager.turnEnd();
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]).toStrictEqual({});
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(0);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(0);
+});
+
+test('Smote - 1 source, 2 casts, 1 stack each', () => {
+    char.statusEffectManager.add(new Smote({
+        char,
+        source: char,
+        stacks: 1
+    }));
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(char)].stacks).toBe(1);
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(charDamage);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(charAccuracy);
+
+    char.statusEffectManager.add(new Smote({
+        char,
+        source: char,
+        stacks: 1
+    }));
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(char)].stacks).toBe(2);
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(charDamage);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(charAccuracy);
+});
+
+test('Smote - 2 sources, 1 and 2 stacks', () => {
+    char.statusEffectManager.add(new Smote({
+        char,
+        source: char,
+        stacks: 1
+    }));
+    char.statusEffectManager.add(new Smote({
+        char,
+        source: source1,
+        stacks: 2
+    }));
+
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(char)].stacks).toBe(1);
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(source1)].stacks).toBe(2);
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(charDamage + source1Damage);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(charAccuracy + source1Accuracy);
+
+    char.statusEffectManager.turnEnd();
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(char)]).toBeUndefined();
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(source1)].stacks).toBe(1);
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(source1Damage);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(source1Accuracy);
+
+    char.statusEffectManager.turnEnd();
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]).toStrictEqual({});
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(0);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(0);
+});
+
+test('Smote - 2 sources, 2 stack each', () => {
+    char.statusEffectManager.add(new Smote({
+        char,
+        source: char,
+        stacks: 2
+    }));
+    char.statusEffectManager.add(new Smote({
+        char,
+        source: source1,
+        stacks: 2
+    }));
+
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(char)].stacks).toBe(2);
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(source1)].stacks).toBe(2);
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(charDamage + source1Damage);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(charAccuracy + source1Accuracy);
+
+    char.statusEffectManager.turnEnd();
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(char)].stacks).toBe(1);
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(source1)].stacks).toBe(1);
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(charDamage + source1Damage);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(charAccuracy + source1Accuracy);
+
+    char.statusEffectManager.turnEnd();
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]).toStrictEqual({});
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(0);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(0);
+});
+
+test('Smote - 3 sources, 1 stack each', () => {
+    char.statusEffectManager.add(new Smote({
+        char,
+        source: char,
+        stacks: 1
+    }));
+    char.statusEffectManager.add(new Smote({
+        char,
+        source: source1,
+        stacks: 2
+    }));
+    char.statusEffectManager.add(new Smote({
+        char,
+        source: source2,
+        stacks: 3
+    }));
+
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(char)].stacks).toBe(1);
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(source1)].stacks).toBe(2);
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(source2)].stacks).toBe(3);
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(charDamage + source1Damage + source2Damage);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(charAccuracy + source1Accuracy + source2Accuracy);
+
+    char.statusEffectManager.turnEnd();
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(char)]).toBeUndefined();
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(source1)].stacks).toBe(1);
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(source2)].stacks).toBe(2);
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(source1Damage + source2Damage);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(source1Accuracy + source2Accuracy);
+
+    char.statusEffectManager.turnEnd();
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(char)]).toBeUndefined();
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(source1)]).toBeUndefined();
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]![getCharBattleId(source2)].stacks).toBe(1);
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(source2Damage);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(source2Accuracy);
+
+    char.statusEffectManager.turnEnd();
+    expect(char.statusEffectManager.debuffs[DebuffId.Smote]!).toStrictEqual({});
+    expect(char.stats.getStat(StatType.Damage)).toBeCloseTo(0);
+    expect(char.stats.getStat(StatType.Accuracy)).toBeCloseTo(0);
+});

--- a/src/StatusEffect/Debuffs/Smote.ts
+++ b/src/StatusEffect/Debuffs/Smote.ts
@@ -1,0 +1,58 @@
+import StatType from '../../Character/Stats/StatType';
+import Debuff from '../Debuff';
+import DebuffId from '../types/DebuffId';
+import StatsInterface, { StatsInterfaceType } from '../interface/StatsInterface';
+import Attributes from '../../Character/Attributes/Attributes';
+import StatusEffectCtorArgs from '../types/StatusEffectCtorArgs';
+
+export default class Smote extends Debuff implements StatsInterface {
+    id = DebuffId.Smote;
+    name = 'Smote';
+
+    static baseAccuracy = 4;
+    static accuracyPerLvl = 0.5;
+    static accuracyPerWisdom = 0.2;
+
+    static baseDamage = 2;
+    static damagePerLvl = 0.5;
+    static damagePerWisdom = 0.2;
+
+    stats: StatsInterfaceType;
+
+    constructor(args: StatusEffectCtorArgs) {
+        super(args);
+        this.stats = {
+            [StatType.Accuracy]: Smote.calcAccuracy(this.source.level, this.source.attributes.wisdom),
+            [StatType.Damage]: Smote.calcDamage(this.source.level, this.source.attributes.wisdom),
+        };
+    }
+
+    static calcAccuracy(level: number, wisdom: number): number {
+        const perLvl = Smote.accuracyPerLvl * (level - 1);
+        const perWisdom = Smote.accuracyPerWisdom * (wisdom - Attributes.DEFAULT_VALUE);
+        return -(Smote.baseAccuracy + perLvl + perWisdom);
+    }
+    static calcDamage(level: number, wisdom: number): number {
+        const perLvl = Smote.damagePerLvl * (level - 1);
+        const perWisdom = Smote.damagePerWisdom * (wisdom - Attributes.DEFAULT_VALUE);
+        return -(Smote.baseDamage + perLvl + perWisdom);
+    }
+
+    onApply() {
+        this.char.stats.addStatusEffectStats(this.stats);
+    }
+    onExpire() {
+        this.char.stats.removeStatusEffectStats(this.stats);
+    }
+
+    onTurnStart() { }
+    onTurnEnd() {
+        this.stacks -= 1;
+        if (this.stacks <= 0) this.manager.removeDebuff(this.id, this.source);
+    }
+    onAttack() { }
+    onAttacked() { }
+
+    onSourceTurnStart() { }
+    onSourceTurnEnd() { }
+}

--- a/src/StatusEffect/Debuffs/Stunned.ts
+++ b/src/StatusEffect/Debuffs/Stunned.ts
@@ -1,0 +1,21 @@
+import Debuff from '../Debuff';
+import DebuffId from '../types/DebuffId';
+
+export default class Stunned extends Debuff {
+    id = DebuffId.Stunned;
+    name = 'Stunned';
+
+    onApply() { }
+    onExpire() { }
+
+    onTurnStart() { }
+    onTurnEnd() {
+        this.stacks -= 1;
+        if (this.stacks <= 0) this.manager.removeDebuff(this.id, this.source);
+    }
+    onAttack() { }
+    onAttacked() { }
+
+    onSourceTurnStart() { }
+    onSourceTurnEnd() { }
+}

--- a/src/StatusEffect/StatusEffect.ts
+++ b/src/StatusEffect/StatusEffect.ts
@@ -8,6 +8,7 @@ import StatusEffectType from './types/StatusEffectType';
 abstract class StatusEffect {
     abstract readonly id: BuffId | DebuffId;
     abstract readonly type: StatusEffectType;
+    abstract readonly name: string;
     readonly manager: StatusEffectManager;
     readonly char: Character;
     readonly source: Character;

--- a/src/StatusEffect/StatusEffect.ts
+++ b/src/StatusEffect/StatusEffect.ts
@@ -38,7 +38,8 @@ abstract class StatusEffect {
     // Char events
     abstract onTurnStart(): void;
     abstract onTurnEnd(): void;
-    abstract onAttack(hit: boolean): void;
+    abstract onAttack(hit: boolean, target: Character): void;
+    abstract onAttacked(hit: boolean, source: Character): void;
     // Source events
     abstract onSourceTurnStart(source: Character): void;
     abstract onSourceTurnEnd(source: Character): void;

--- a/src/StatusEffect/StatusEffectManager.ts
+++ b/src/StatusEffect/StatusEffectManager.ts
@@ -141,15 +141,15 @@ export default class StatusEffectManager {
         for (const debuff of Object.values(this.outgoingDebuffs)) debuff.onSourceTurnEnd(this.char);
     }
 
-    onAttack(hit: boolean) {
+    onAttack(hit: boolean, target: Character) {
         for (const buffId of Object.values(this.buffs)) {
             for (const buff of Object.values(buffId)) {
-                buff.onAttack(hit);
+                buff.onAttack(hit, target);
             }
         }
         for (const debuffId of Object.values(this.debuffs)) {
             for (const debuff of Object.values(debuffId)) {
-                debuff.onAttack(hit);
+                debuff.onAttack(hit, target);
             }
         }
     }

--- a/src/StatusEffect/types/BuffId.ts
+++ b/src/StatusEffect/types/BuffId.ts
@@ -1,6 +1,7 @@
 enum BuffId {
     Invisible = 'Invisible',
     Blessed = 'Blessed',
+    ShieldWall = 'ShieldWall',
 }
 
 export default BuffId;

--- a/src/StatusEffect/types/BuffId.ts
+++ b/src/StatusEffect/types/BuffId.ts
@@ -2,6 +2,7 @@ enum BuffId {
     Invisible = 'Invisible',
     Blessed = 'Blessed',
     ShieldWall = 'ShieldWall',
+    EnvenomWeapon = 'EnvenomWeapon'
 }
 
 export default BuffId;

--- a/src/StatusEffect/types/DebuffId.ts
+++ b/src/StatusEffect/types/DebuffId.ts
@@ -4,6 +4,7 @@ enum DebuffId {
     Frozen = 'Frozen',
     Bleeding = 'Bleeding',
     Stunned = 'Stunned',
+    Smote = 'Smote'
 }
 
 export default DebuffId;

--- a/src/StatusEffect/types/DebuffId.ts
+++ b/src/StatusEffect/types/DebuffId.ts
@@ -2,7 +2,8 @@ enum DebuffId {
     Burning = 'Burning',
     Poisoned = 'Poisoned',
     Frozen = 'Frozen',
-    Bleeding = 'Bleeding'
+    Bleeding = 'Bleeding',
+    Stunned = 'Stunned',
 }
 
 export default DebuffId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,9 @@ import Character from './Character/Character';
 export { Character };
 
 import Ability from './Ability/Ability';
-export { Ability };
+import AbilityId from './Ability/AbilityId';
+import abilities from './Ability/abilities';
+export { Ability, AbilityId, abilities };
 
 import Attributes from './Character/Attributes/Attributes';
 export { Attributes };

--- a/src/npc/Fighter.ts
+++ b/src/npc/Fighter.ts
@@ -1,8 +1,8 @@
 import { startingAbility, startingEquipment } from '../Character/Classes/classLoadouts';
 import AttributeType from '../Character/Attributes/AttributeType';
-import { ClassName } from '../Character/Classes/classes';
 import StatType from '../Character/Stats/StatType';
 import NPC from './NPC';
+import ClassName from '../Character/Classes/ClassName';
 
 const Fighter: NPC = {
     id: 'fighter',

--- a/src/npc/GoblinFighter.ts
+++ b/src/npc/GoblinFighter.ts
@@ -1,6 +1,6 @@
 import AttributeType from '../Character/Attributes/AttributeType';
-import { ClassName } from '../Character/Classes/classes';
 import { startingAbility } from '../Character/Classes/classLoadouts';
+import ClassName from '../Character/Classes/ClassName';
 import StatType from '../Character/Stats/StatType';
 import { armour } from '../Equipment/Armour';
 import { EquipSlot } from '../Equipment/Equipment';

--- a/src/npc/GoblinRogue.ts
+++ b/src/npc/GoblinRogue.ts
@@ -1,6 +1,6 @@
 import AttributeType from '../Character/Attributes/AttributeType';
-import { ClassName } from '../Character/Classes/classes';
 import { startingAbility } from '../Character/Classes/classLoadouts';
+import ClassName from '../Character/Classes/ClassName';
 import StatType from '../Character/Stats/StatType';
 import { armour } from '../Equipment/Armour';
 import { EquipSlot } from '../Equipment/Equipment';

--- a/src/npc/NPC.ts
+++ b/src/npc/NPC.ts
@@ -1,8 +1,8 @@
-import Ability from '../Ability/Ability';
-import AttributeTemplate from '../Character/Attributes/AttributeTemplate';
-import { ClassName } from '../Character/Classes/classes';
-import { StatTemplate } from '../Character/Stats/StatTemplate';
-import { EquipmentImport } from '../Equipment/Equipment';
+import type Ability from '../Ability/Ability';
+import type AttributeTemplate from '../Character/Attributes/AttributeTemplate';
+import type ClassName from '../Character/Classes/ClassName';
+import { type StatTemplate } from '../Character/Stats/StatTemplate';
+import { type EquipmentImport } from '../Equipment/Equipment';
 
 type NpcId = 'fighter' | 'rogue' | 'wizard' |
     'goblinFighter' | 'goblinRogue' | 'orcFighter' | 'ogreFighter' | 'rat' | 'zombie' | 'wolf';

--- a/src/npc/OgreFighter.ts
+++ b/src/npc/OgreFighter.ts
@@ -1,6 +1,6 @@
 import AttributeType from '../Character/Attributes/AttributeType';
+import ClassName from '../Character/Classes/ClassName';
 import { startingAbility } from '../Character/Classes/classLoadouts';
-import { ClassName } from '../Character/Classes/classes';
 import StatType from '../Character/Stats/StatType';
 import Stats from '../Character/Stats/Stats';
 import { armour } from '../Equipment/Armour';

--- a/src/npc/OrcFighter.ts
+++ b/src/npc/OrcFighter.ts
@@ -1,6 +1,6 @@
 import AttributeType from '../Character/Attributes/AttributeType';
+import ClassName from '../Character/Classes/ClassName';
 import { startingAbility } from '../Character/Classes/classLoadouts';
-import { ClassName } from '../Character/Classes/classes';
 import StatType from '../Character/Stats/StatType';
 import Stats from '../Character/Stats/Stats';
 import { armour } from '../Equipment/Armour';

--- a/src/npc/Rogue.ts
+++ b/src/npc/Rogue.ts
@@ -1,6 +1,6 @@
 import AttributeType from '../Character/Attributes/AttributeType';
-import { ClassName } from '../Character/Classes/classes';
 import { startingAbility, startingEquipment } from '../Character/Classes/classLoadouts';
+import ClassName from '../Character/Classes/ClassName';
 import StatType from '../Character/Stats/StatType';
 import NPC from './NPC';
 

--- a/src/npc/Wizard.ts
+++ b/src/npc/Wizard.ts
@@ -1,6 +1,6 @@
 import AttributeType from '../Character/Attributes/AttributeType';
-import { ClassName } from '../Character/Classes/classes';
 import { startingAbility, startingEquipment } from '../Character/Classes/classLoadouts';
+import ClassName from '../Character/Classes/ClassName';
 import StatType from '../Character/Stats/StatType';
 import NPC from './NPC';
 

--- a/src/types/AttackType.ts
+++ b/src/types/AttackType.ts
@@ -1,6 +1,6 @@
 enum AttackType {
-    MeleeWeapon = 'Melee',
-    RangedWeapon = 'Ranged',
+    MeleeWeapon = 'Melee Weapon',
+    RangedWeapon = 'Ranged Weapon',
     Spell = 'Spell'
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,7 @@
 import type Ability from './Ability/Ability';
 import type BaseAttributes from './Character/Attributes/BaseAttributes';
 import Character from './Character/Character';
-import { type ClassName } from './Character/Classes/classes';
+import type ClassName from './Character/Classes/ClassName';
 import { type StatTemplate } from './Character/Stats/StatTemplate';
 import { type EquipmentImport } from './Equipment/Equipment';
 import type BuffId from './StatusEffect/types/BuffId';


### PR DESCRIPTION
### New ability for each class
- Fighter - Shield Wall
- Priest - Smite
- Ranger - Serpent Sting
- Rogue - Envenom Weapon
- Wizard - Frostbolt

### Changes
- Adjust ability descriptions
- Update Vanish to have Invisible stacks to also scale with character level.
- Add **scaling** property to abilities for use in ability tooltips in client.

### Fixes
- Fix Firebolt level scaling starting at level 1 instead of 2.